### PR TITLE
Keep CPU usage lower

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -179,7 +179,7 @@ impl<'a> App<'a> {
             terminal.draw(|f| self.draw(f))?;
 
             // get event
-            match self.rx.recv_timeout(Duration::from_secs(60)) {
+            match self.rx.recv() {
                 // Get terminal event.
                 Ok(AppEvent::TerminalEvent(terminal_event)) => self.get_event(terminal_event),
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -123,10 +123,7 @@ impl View {
 }
 
 fn send_input(tx: Sender<AppEvent>) -> io::Result<()> {
-    let timeout = Duration::from_millis(5);
-    if crossterm::event::poll(timeout)? {
-        let event = crossterm::event::read().expect("failed to read crossterm event");
-        let _ = tx.clone().send(AppEvent::TerminalEvent(event));
-    }
+    let event = crossterm::event::read().expect("failed to read crossterm event");
+    let _ = tx.send(AppEvent::TerminalEvent(event));
     Ok(())
 }


### PR DESCRIPTION
I think the high CPU usage rate ( #47 ) is caused by the thread which is monitoring the event of the terminal.
This thread loops very frequently.
https://github.com/blacknon/hwatch/blob/0.3.3/src/view.rs#L78-L83

Therefore, I am wondering if the non-blocking functions under the thread could be replaced with blocking function.
Even if the function blocks the thread, main thread would not be affected.

For example, using [crossterm::event::read()](https://docs.rs/crossterm/0.17.7/crossterm/event/fn.read.html) without `poll()` blocks the thread, but it would not be the problem because it is not main thread.
The reason why using `rx.recv()` instead of `rx.recv_timeout()` is same.

But , I am not 100% sure `hwatch` works after this changes, since I am not familiar with this project and crossterm library.
If there is any problem, please let me know 👍 