### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ That records the result of command execution and can display it history and diff
 
 ### macOS (brew)
 
-    brew tap blacknon/hwatch
     brew install hwatch
 
 ### macOS (MacPorts)


### PR DESCRIPTION
[`hwatch` has been added into `homebrew-core`](https://github.com/Homebrew/homebrew-core/pull/103409) and can be installed without tap now!