### PR TITLE
Do not request mouse events from the terminal (for now)

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -5,7 +5,7 @@
 use crossbeam_channel::{Receiver, Sender};
 // module
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
+    // event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -74,7 +74,11 @@ impl View {
         // Setup Terminal
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(
+            stdout,
+            EnterAlternateScreen,
+            // EnableMouseCapture,
+        )?;
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
         let _ = terminal.clear();
@@ -114,7 +118,7 @@ impl View {
         execute!(
             terminal.backend_mut(),
             LeaveAlternateScreen,
-            DisableMouseCapture
+            // DisableMouseCapture
         )?;
         terminal.show_cursor()?;
 


### PR DESCRIPTION
Currently, the mouse isn't supported, but mouse events are requested from the terminal. This causes some unexpected behavior. This commit stops requesting mouse events.

Once mouse support is implemented (which would be great!), there should probably be an option to disable it for the same reason.

This will help with https://github.com/blacknon/hwatch/issues/51 and https://github.com/blacknon/hwatch/issues/66.