### PR TITLE
Mouse wheel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,25 +63,29 @@ That records the result of command execution and can display it history and diff
 
 watch window keybind
 
-- <kbd>↑</kbd>, <kbd>↓</kbd>  ... move selected screen(history/watch).
-- <kbd>←</kbd>   ... select watch screen.
-- <kbd>→</kbd>   ... select history screen.
-- <kbd>H</kbd>   ... show help window.
-- <kbd>C</kbd>   ... toggle color.
-- <kbd>D</kbd>   ... switch diff mode.
-- <kbd>N</kbd>   ... switch line number display.
-- <kbd>Q</kbd>   ... exit hwatch.
-- <kbd>0</kbd>   ... disable diff.
-- <kbd>1</kbd>   ... switch watch type diff.
-- <kbd>2</kbd>   ... switch line type diff.
-- <kbd>3</kbd>   ... switch word type diff.
-- <kbd>F1</kbd>  ... only stdout print.
-- <kbd>F2</kbd>  ... only stderr print.
-- <kbd>F3</kbd>  ... print output.
-- <kbd>Tab</kbd> ... toggle select screen(history/watch).
-- <kbd>/</kbd>   ... filter history by string.
-- <kbd>*</kbd>   ... filter history by regex.
-- <kbd>Esc</kbd> ... unfiltering.
+| Key            | Action
+|----------------|-------------------------
+| <kbd>↑</kbd>, <kbd>↓</kbd>  | move selected screen(history/watch).
+| <kbd>←</kbd>   | select watch screen.
+| <kbd>→</kbd>   | select history screen.
+| <kbd>H</kbd>   | show help window.
+| <kbd>C</kbd>   | toggle color.
+| <kbd>D</kbd>   | switch diff mode.
+| <kbd>N</kbd>   | switch line number display.
+| <kbd>T</kbd>   | toggle the UI (history pane and header).
+| <kbd>Backspace</kbd>   | toggle the history pane.
+| <kbd>Q</kbd>   | exit hwatch.
+| <kbd>0</kbd>   | disable diff.
+| <kbd>1</kbd>   | switch watch type diff.
+| <kbd>2</kbd>   | switch line type diff.
+| <kbd>3</kbd>   | switch word type diff.
+| <kbd>F1</kbd>  | only stdout print.
+| <kbd>F2</kbd>  | only stderr print.
+| <kbd>F3</kbd>  | print output.
+| <kbd>Tab</kbd> | toggle select screen(history/watch).
+| <kbd>/</kbd>   | filter history by string.
+| <kbd>*</kbd>   | filter history by regex.
+| <kbd>Esc</kbd> | unfiltering.
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ That records the result of command execution and can display it history and diff
 
 ## Usage
 
-    hwatch 0.3.7
+    hwatch 0.3.8
     blacknon <blacknon@orebibou.com>
     A modern alternative to the watch command, records the differences in execution results and can
     check this differences at after.
@@ -45,12 +45,15 @@ That records the result of command execution and can display it history and diff
         hwatch [OPTIONS] <command>...
 
     ARGS:
-        <command>...
+        <command>...    
 
     OPTIONS:
+        -B, --beep                     beep if command has a change result
         -c, --color                    interpret ANSI color and style sequences
         -d, --differences              highlight changes between updates
+        -t, --no-title                 hide the UI on start. Use `t` to toggle it.
         -N, --line-number              show line number
+            --no-help-banner           hide the "Display help with h key" message
         -x, --exec                     Run the command directly, not through the shell. Much like the
                                        `-x` option of the watch command.
         -l, --logfile <logfile>        logging file
@@ -59,7 +62,6 @@ That records the result of command execution and can display it history and diff
         -n, --interval <interval>      seconds to wait between updates [default: 2]
         -h, --help                     Print help information
         -V, --version                  Print version information
-
 
 watch window keybind
 
@@ -87,6 +89,16 @@ watch window keybind
 | <kbd>*</kbd>   | filter history by regex.
 | <kbd>Esc</kbd> | unfiltering.
 
+
+## Configuration
+
+If you always want to use some command-line options, you can set them in the
+`HWATCH` environment variable. For example, if you use `bash`, you can add
+the following to your `.bashrc`:
+
+```bash
+export HWATCH="--no-title --color --no-help-banner"
+```
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ That records the result of command execution and can display it history and diff
     OPTIONS:
         -B, --beep                     beep if command has a change result
         -c, --color                    interpret ANSI color and style sequences
+            --mouse                    enable mouse wheel support. With this option, copying text
+                                       with your terminal may be harder. Try holding the Shift key.
         -d, --differences              highlight changes between updates
         -t, --no-title                 hide the UI on start. Use `t` to toggle it.
         -N, --line-number              show line number

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,7 +15,6 @@ use tui::{
     Frame, Terminal,
 };
 
-
 // local module
 use crate::common::logging_result;
 use crate::event::AppEvent;
@@ -332,13 +331,21 @@ impl<'a> App<'a> {
                 output::get_watch_diff(self.ansi_color, self.line_number, text_src, text_dst)
             }
 
-            DiffMode::Line => {
-                output::get_line_diff(self.ansi_color, self.line_number, self.is_only_diffline, text_src, text_dst)
-            }
+            DiffMode::Line => output::get_line_diff(
+                self.ansi_color,
+                self.line_number,
+                self.is_only_diffline,
+                text_src,
+                text_dst,
+            ),
 
-            DiffMode::Word => {
-                output::get_word_diff(self.ansi_color, self.line_number, self.is_only_diffline, text_src, text_dst)
-            }
+            DiffMode::Word => output::get_word_diff(
+                self.ansi_color,
+                self.line_number,
+                self.is_only_diffline,
+                text_src,
+                text_dst,
+            ),
         };
 
         self.watch_area.update_output(output_data);
@@ -429,7 +436,7 @@ impl<'a> App<'a> {
         let mut tmp_history = vec![];
 
         // append result.
-        let latest_num:usize;
+        let latest_num: usize;
         if counter > 1 {
             latest_num = counter - 1;
         } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -91,6 +91,9 @@ pub struct App<'a> {
     is_regex_filter: bool,
 
     ///
+    show_history: bool,
+
+    ///
     filtered_text: String,
 
     ///
@@ -142,6 +145,7 @@ impl<'a> App<'a> {
 
             ansi_color: false,
             line_number: false,
+            show_history: true,
 
             is_beep: false,
             is_filtered: false,
@@ -185,6 +189,8 @@ impl<'a> App<'a> {
 
             // get event
             match self.rx.recv() {
+                Ok(AppEvent::Redraw) => update_draw = true,
+
                 // Get terminal event.
                 Ok(AppEvent::TerminalEvent(terminal_event)) => {
                     self.get_event(terminal_event);
@@ -206,7 +212,7 @@ impl<'a> App<'a> {
                 // get exit event
                 Ok(AppEvent::Exit) => self.done = true,
 
-                _ => {}
+                Err(_) => {}
             }
         }
     }
@@ -221,8 +227,10 @@ impl<'a> App<'a> {
         // Draw watch area.
         self.watch_area.draw(f);
 
-        // Draw history area
-        self.history_area.draw(f);
+        if self.show_history {
+            // Draw history area
+            self.history_area.draw(f);
+        }
 
         // match help mode
         if let ActiveWindow::Help = self.window {
@@ -250,11 +258,17 @@ impl<'a> App<'a> {
         let top_chunks = Layout::default()
             .constraints([Constraint::Length(2), Constraint::Max(0)].as_ref())
             .split(total_area);
+
+        let history_width: u16 = match self.show_history {
+            true => HISTORY_WIDTH,
+            false => 0,
+        };
+
         let main_chunks = Layout::default()
             .constraints(
                 [
-                    Constraint::Max(total_area.width - HISTORY_WIDTH),
-                    Constraint::Length(HISTORY_WIDTH),
+                    Constraint::Max(total_area.width - history_width),
+                    Constraint::Length(history_width),
                 ]
                 .as_ref(),
             )
@@ -703,6 +717,13 @@ impl<'a> App<'a> {
                     }
 
                     // Common input key
+                    // Backspace ... toggle history panel.
+                    Event::Key(KeyEvent {
+                        code: KeyCode::Backspace,
+                        modifiers: KeyModifiers::NONE,
+                    }) => self.toggle_history(),
+
+                    // Common input key
                     // h ... toggel help window.
                     Event::Key(KeyEvent {
                         code: KeyCode::Char('h'),
@@ -881,6 +902,12 @@ impl<'a> App<'a> {
             ActiveWindow::Normal => self.window = ActiveWindow::Help,
             ActiveWindow::Help => self.window = ActiveWindow::Normal,
         }
+    }
+
+    ///
+    fn toggle_history(&mut self) {
+        self.show_history = !self.show_history;
+        let _ = self.tx.send(AppEvent::Redraw);
     }
 
     ///

--- a/src/app.rs
+++ b/src/app.rs
@@ -945,6 +945,19 @@ impl<'a> App<'a> {
     }
 
     ///
+    pub fn show_help_banner(&mut self, visible: bool) {
+        self.header_area.set_banner(
+            if visible {
+                "Display help with h key!"
+            } else {
+                ""
+            }
+            .to_string(),
+        );
+        let _ = self.tx.send(AppEvent::Redraw);
+    }
+
+    ///
     fn input_key_up(&mut self) {
         match self.window {
             ActiveWindow::Normal => match self.area {

--- a/src/app.rs
+++ b/src/app.rs
@@ -731,14 +731,14 @@ impl<'a> App<'a> {
                     Event::Key(KeyEvent {
                         code: KeyCode::Backspace,
                         modifiers: KeyModifiers::NONE,
-                    }) => self.toggle_history(),
+                    }) => self.show_history(!self.show_history),
 
                     // Common input key
                     // t ... toggle ui
                     Event::Key(KeyEvent {
                         code: KeyCode::Char('t'),
                         modifiers: KeyModifiers::NONE,
-                    }) => self.toggle_ui(),
+                    }) => self.show_ui(!self.show_header),
 
                     // Common input key
                     // h ... toggle help window.
@@ -880,17 +880,20 @@ impl<'a> App<'a> {
     //    }
     //}
 
+    fn set_area(&mut self, target: ActiveArea) {
+        self.area = target;
+        // set active window to header.
+        self.header_area.set_active_area(self.area);
+        self.header_area.update();
+    }
+
     ///
     fn toggle_area(&mut self) {
         if let ActiveWindow::Normal = self.window {
             match self.area {
-                ActiveArea::Watch => self.area = ActiveArea::History,
-                ActiveArea::History => self.area = ActiveArea::Watch,
+                ActiveArea::Watch => self.set_area(ActiveArea::History),
+                ActiveArea::History => self.set_area(ActiveArea::Watch),
             }
-
-            // set active window to header.
-            self.header_area.set_active_area(self.area);
-            self.header_area.update();
         }
     }
 
@@ -922,15 +925,18 @@ impl<'a> App<'a> {
     }
 
     ///
-    fn toggle_history(&mut self) {
-        self.show_history = !self.show_history;
+    pub fn show_history(&mut self, visible: bool) {
+        self.show_history = visible;
+        if !visible {
+            self.set_area(ActiveArea::Watch);
+        }
         let _ = self.tx.send(AppEvent::Redraw);
     }
 
     ///
-    fn toggle_ui(&mut self) {
-        self.show_header = !self.show_header;
-        self.show_history = self.show_header;
+    pub fn show_ui(&mut self, visible: bool) {
+        self.show_header = visible;
+        self.show_history = visible;
         let _ = self.tx.send(AppEvent::Redraw);
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -436,12 +436,7 @@ impl<'a> App<'a> {
         let mut tmp_history = vec![];
 
         // append result.
-        let latest_num: usize;
-        if counter > 1 {
-            latest_num = counter - 1;
-        } else {
-            latest_num = 0;
-        }
+        let latest_num: usize = if counter > 1 { counter - 1 } else { 0 };
 
         tmp_history.push(History {
             timestamp: "latest                 ".to_string(),
@@ -563,7 +558,7 @@ impl<'a> App<'a> {
         // update WatchArea
         self.set_output_data(selected);
 
-        return true;
+        true
     }
 
     ///

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,7 @@
 
 use crossbeam_channel::{Receiver, Sender};
 // module
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use regex::Regex;
 use std::{collections::HashMap, io};
 use tui::{
@@ -606,6 +606,31 @@ impl<'a> App<'a> {
                         modifiers: KeyModifiers::NONE,
                     }) => self.input_key_down(),
 
+                    // mouse wheel up
+                    Event::Mouse(MouseEvent {
+                        kind: MouseEventKind::ScrollUp,
+                        modifiers: KeyModifiers::NONE,
+                        ..
+                    }) => self.mouse_scroll_up(),
+
+                    // mouse wheel down
+                    Event::Mouse(MouseEvent {
+                        kind: MouseEventKind::ScrollDown,
+                        modifiers: KeyModifiers::NONE,
+                        ..
+                    }) => self.mouse_scroll_down(),
+
+                    Event::Mouse(MouseEvent {
+                        kind: MouseEventKind::Down(crossterm::event::MouseButton::Left),
+                        column,
+                        row,
+                        modifiers: KeyModifiers::NONE,
+                        ..
+                    }) => {
+                        // Currently a no-op
+                        self.mouse_click_left(column, row);
+                    }
+
                     // pgup
 
                     // pgdn
@@ -769,8 +794,6 @@ impl<'a> App<'a> {
                         .send(AppEvent::Exit)
                         .expect("send error hwatch exit."),
 
-                    // mouse event.
-                    // Event::Mouse(ref mouse_event) => self.get_input_mouse_event(mouse_event),
                     _ => {}
                 }
             }
@@ -874,15 +897,6 @@ impl<'a> App<'a> {
             }
         }
     }
-
-    // Not currently used.
-    ///
-    //fn get_input_mouse_event(&mut self, mouse_event: &MouseEvent) {
-    //    let mouse_event_tupple = (mouse_event.kind, mouse_event.modifiers);
-    //    if let (MouseEventKind::Down(MouseButton::Left), KeyModifiers::NONE) = mouse_event_tupple {
-    //        self.mouse_click_left(mouse_event.column, mouse_event.row);
-    //    }
-    //}
 
     fn set_area(&mut self, target: ActiveArea) {
         self.area = target;
@@ -1003,6 +1017,15 @@ impl<'a> App<'a> {
         }
     }
 
+    // Mouse wheel always scrolls the main area
+    fn mouse_scroll_up(&mut self) {
+        self.watch_area.scroll_up(2);
+    }
+
+    fn mouse_scroll_down(&mut self) {
+        self.watch_area.scroll_down(2);
+    }
+
     // NOTE: TODO:
     // Not currently used.
     // It will not be supported until the following issues are resolved.
@@ -1039,27 +1062,22 @@ impl<'a> App<'a> {
         }
     }
 
-    // NOTE: TODO:
-    // Not currently used.
-    // It will not be supported until the following issues are resolved.
+    // NOTE: TODO: Currently does not do anything
+    // Mouse clicks will not be supported until the following issues are resolved.
     //     - https://github.com/fdehau/tui-rs/issues/495
-    //fn mouse_click_left(&mut self, column: u16, row: u16) {
-    //    // check in hisotry area
-    //    let is_history_area = check_in_area(self.history_area.area, column, row);
-    //    if is_history_area {
-    //        // let headline_count = self.history_area.area.y;
-    //        // self.history_area.click_row(row - headline_count);
+    fn mouse_click_left(&mut self, _column: u16, _row: u16) {
+        //    // check in hisotry area
+        //    let is_history_area = check_in_area(self.history_area.area, column, row);
+        //    if is_history_area {
+        //        // let headline_count = self.history_area.area.y;
+        //        // self.history_area.click_row(row - headline_count);
 
-    //        // self.history_area.previous();
+        //        // self.history_area.previous();
 
-    //        let selected = self.history_area.get_state_select();
-    //        self.set_output_data(selected);
-    //    }
-    //}
-
-    //fn mouse_scroll_up(&mut self, _column: u16, _row: u16) {}
-
-    //fn mouse_scroll_down(&mut self, _column: u16, _row: u16) {}
+        //        let selected = self.history_area.get_state_select();
+        //        self.set_output_data(selected);
+        //    }
+    }
 }
 
 //fn check_in_area(area: Rect, column: u16, row: u16) -> bool {

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,21 +29,21 @@ use crate::watch::WatchArea;
 use crate::HISTORY_WIDTH;
 
 ///
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ActiveArea {
     Watch,
     History,
 }
 
 ///
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum ActiveWindow {
     Normal,
     Help,
 }
 
 ///
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum DiffMode {
     Disable,
     Watch,
@@ -52,7 +52,7 @@ pub enum DiffMode {
 }
 
 ///
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum OutputMode {
     Output,
     Stdout,
@@ -60,7 +60,7 @@ pub enum OutputMode {
 }
 
 ///
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
     None,
     Filter,
@@ -234,7 +234,8 @@ impl<'a> App<'a> {
         self.watch_area.draw(f);
 
         if self.show_history {
-            // Draw history area
+            self.history_area
+                .set_active(self.area == ActiveArea::History);
             self.history_area.draw(f);
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -233,11 +233,9 @@ impl<'a> App<'a> {
         // Draw watch area.
         self.watch_area.draw(f);
 
-        if self.show_history {
-            self.history_area
-                .set_active(self.area == ActiveArea::History);
-            self.history_area.draw(f);
-        }
+        self.history_area
+            .set_active(self.area == ActiveArea::History);
+        self.history_area.draw(f);
 
         // match help mode
         if let ActiveWindow::Help = self.window {
@@ -264,7 +262,12 @@ impl<'a> App<'a> {
     fn define_subareas(&mut self, total_area: tui::layout::Rect) {
         let history_width: u16 = match self.show_history {
             true => HISTORY_WIDTH,
-            false => 0,
+            false => match self.area == ActiveArea::History
+                || self.history_area.get_state_select() != 0
+            {
+                true => 2,
+                false => 0,
+            },
         };
         let header_height: u16 = match self.show_header {
             true => 2,

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,9 +4,9 @@
 
 // module
 use chrono::Local;
+use std::error::Error;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
-use std::error::Error;
 
 // local module
 use crate::exec::CommandResult;
@@ -17,13 +17,15 @@ pub fn now_str() -> String {
 }
 
 /// logging result data to log file(_logpath).
-pub fn logging_result(_logpath: &str, _result: &CommandResult) ->  Result<(), Box<dyn Error>> {
+pub fn logging_result(_logpath: &str, _result: &CommandResult) -> Result<(), Box<dyn Error>> {
     // try open logfile
-    let mut logfile = match OpenOptions::new().write(true)
+    let mut logfile = match OpenOptions::new()
+        .write(true)
         .create(true)
         .append(true)
-        .open(_logpath) {
-        Err(why) => {return Err(Box::new(why))},
+        .open(_logpath)
+    {
+        Err(why) => return Err(Box::new(why)),
         Ok(file) => file,
     };
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -34,7 +34,7 @@ pub fn logging_result(_logpath: &str, _result: &CommandResult) -> Result<(), Box
 
     // write log
     // TODO(blacknon): warning出てるので対応
-    _ = writeln!(logfile, "{}", logdata);
+    _ = writeln!(logfile, "{logdata}");
 
     Ok(())
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,5 +7,6 @@ use crate::exec::CommandResult;
 pub enum AppEvent {
     OutputUpdate(CommandResult),
     TerminalEvent(crossterm::event::Event),
+    Redraw,
     Exit,
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -155,7 +155,7 @@ impl ExecuteCommand {
 
                             (stdout.len(), stderr.len())
                         }
-                        other => panic!("Some better error handling here, {:?}", other),
+                        other => panic!("Some better error handling here, {other:?}"),
                     };
 
                     if stdout_bytes == 0 && stderr_bytes == 0 {
@@ -211,9 +211,11 @@ mod tests {
     #[test]
     fn test_command_result_comparison() {
         let command_result = CommandResult::default();
-        let mut command_result_2 = CommandResult::default();
+        let command_result_2 = CommandResult {
+            timestamp: "SomeOtherTime".to_string(),
+            ..Default::default()
+        };
         //Timestamp is not part of the comparison. Let's ensure it's different to prove.
-        command_result_2.timestamp = "SomeOtherTime".to_string();
         assert!(command_result == command_result_2);
     }
 
@@ -240,40 +242,50 @@ mod tests {
     #[test]
     fn test_command_result_command_diff() {
         let command_result1 = CommandResult::default();
-        let mut command_result2 = CommandResult::default();
-        command_result2.command = "different".to_string();
+        let command_result2 = CommandResult {
+            command: "different".to_string(),
+            ..Default::default()
+        };
         assert!(command_result1 != command_result2);
     }
 
     #[test]
     fn test_command_result_status_diff() {
         let command_result1 = CommandResult::default();
-        let mut command_result2 = CommandResult::default();
-        command_result2.status = false;
+        let command_result2 = CommandResult {
+            status: false,
+            ..Default::default()
+        };
         assert!(command_result1 != command_result2);
     }
 
     #[test]
     fn test_command_result_output_diff() {
         let command_result1 = CommandResult::default();
-        let mut command_result2 = CommandResult::default();
-        command_result2.output = "different".to_string();
+        let command_result2 = CommandResult {
+            output: "different".to_string(),
+            ..Default::default()
+        };
         assert!(command_result1 != command_result2);
     }
 
     #[test]
     fn test_command_result_stdout_diff() {
         let command_result1 = CommandResult::default();
-        let mut command_result2 = CommandResult::default();
-        command_result2.stdout = "different".to_string();
+        let command_result2 = CommandResult {
+            stdout: "different".to_string(),
+            ..Default::default()
+        };
         assert!(command_result1 != command_result2);
     }
 
     #[test]
     fn test_command_result_stderr_diff() {
         let command_result1 = CommandResult::default();
-        let mut command_result2 = CommandResult::default();
-        command_result2.stderr = "different".to_string();
+        let command_result2 = CommandResult {
+            stderr: "different".to_string(),
+            ..Default::default()
+        };
         assert!(command_result1 != command_result2);
     }
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -202,7 +202,6 @@ impl ExecuteCommand {
     }
 }
 
-
 // pub fn exec_after_comamnd(){}
 
 #[cfg(test)]

--- a/src/header.rs
+++ b/src/header.rs
@@ -60,7 +60,6 @@ pub struct HeaderArea<'a> {
     ///
     is_only_diffline: bool,
 
-
     ///
     output_mode: OutputMode,
 
@@ -198,24 +197,24 @@ impl<'a> HeaderArea<'a> {
         let value_number: Span = match self.line_number {
             true => Span::styled(
                 format!("Number"),
-                Style::default().fg(Color::Green).add_modifier(Modifier::REVERSED).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::REVERSED)
+                    .add_modifier(Modifier::BOLD),
             ),
-            false => Span::styled(
-                format!("Number"),
-                Style::default().fg(Color::Reset),
-            ),
+            false => Span::styled(format!("Number"), Style::default().fg(Color::Reset)),
         };
 
         // Set Color flag value
         let value_color: Span = match self.ansi_color {
             true => Span::styled(
                 format!("Color"),
-                Style::default().fg(Color::Green).add_modifier(Modifier::REVERSED).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::REVERSED)
+                    .add_modifier(Modifier::BOLD),
             ),
-            false => Span::styled(
-                format!("Color"),
-                Style::default().fg(Color::Reset),
-            ),
+            false => Span::styled(format!("Color"), Style::default().fg(Color::Reset)),
         };
 
         // Set output type value
@@ -295,7 +294,9 @@ impl<'a> HeaderArea<'a> {
             Span::styled("Output:", Style::default().add_modifier(Modifier::BOLD)),
             Span::styled(
                 format!("{:wid$}", value_output, wid = 6),
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::REVERSED),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::REVERSED),
             ),
             Span::raw("]"),
             Span::raw(" "),
@@ -304,7 +305,9 @@ impl<'a> HeaderArea<'a> {
             Span::styled("Active: ", Style::default().add_modifier(Modifier::BOLD)),
             Span::styled(
                 format!("{:wid$}", value_active, wid = 7),
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::REVERSED),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::REVERSED),
             ),
             Span::raw("]"),
             Span::raw(" "),
@@ -313,7 +316,9 @@ impl<'a> HeaderArea<'a> {
             Span::styled("Diff: ", Style::default().add_modifier(Modifier::BOLD)),
             Span::styled(
                 format!("{:wid$}", value_diff, wid = 10),
-                Style::default().fg(Color::Magenta).add_modifier(Modifier::REVERSED),
+                Style::default()
+                    .fg(Color::Magenta)
+                    .add_modifier(Modifier::REVERSED),
             ),
             Span::raw("]"),
         ]));

--- a/src/header.rs
+++ b/src/header.rs
@@ -196,25 +196,25 @@ impl<'a> HeaderArea<'a> {
         // Set number flag value
         let value_number: Span = match self.line_number {
             true => Span::styled(
-                format!("Number"),
+                "Number".to_string(),
                 Style::default()
                     .fg(Color::Green)
                     .add_modifier(Modifier::REVERSED)
                     .add_modifier(Modifier::BOLD),
             ),
-            false => Span::styled(format!("Number"), Style::default().fg(Color::Reset)),
+            false => Span::styled("Number".to_string(), Style::default().fg(Color::Reset)),
         };
 
         // Set Color flag value
         let value_color: Span = match self.ansi_color {
             true => Span::styled(
-                format!("Color"),
+                "Color".to_string(),
                 Style::default()
                     .fg(Color::Green)
                     .add_modifier(Modifier::REVERSED)
                     .add_modifier(Modifier::BOLD),
             ),
-            false => Span::styled(format!("Color"), Style::default().fg(Color::Reset)),
+            false => Span::styled("Color".to_string(), Style::default().fg(Color::Reset)),
         };
 
         // Set output type value
@@ -231,19 +231,14 @@ impl<'a> HeaderArea<'a> {
         };
 
         // Set IsOnlyDiffline value
-        let value_only_diffline: &str;
-        if self.is_only_diffline {
-            value_only_diffline = "(Only)";
-        } else {
-            value_only_diffline = "";
-        }
+        let value_only_diffline = if self.is_only_diffline { "(Only)" } else { "" };
 
         // Set Diff mode value
         let value_diff = match self.diff_mode {
             DiffMode::Disable => "None".to_string(),
             DiffMode::Watch => "Watch".to_string(),
-            DiffMode::Line => ("Line".to_string() + value_only_diffline).to_string(),
-            DiffMode::Word => ("Word".to_string() + value_only_diffline).to_string(),
+            DiffMode::Line => "Line".to_string() + value_only_diffline,
+            DiffMode::Word => "Word".to_string() + value_only_diffline,
         };
 
         // Set Color

--- a/src/header.rs
+++ b/src/header.rs
@@ -61,6 +61,9 @@ pub struct HeaderArea<'a> {
     is_only_diffline: bool,
 
     ///
+    banner: String,
+
+    ///
     output_mode: OutputMode,
 
     ///
@@ -88,6 +91,7 @@ impl<'a> HeaderArea<'a> {
             data: vec![Spans::from("")],
             ansi_color: false,
             line_number: false,
+            banner: "".to_string(),
 
             active_area: ActiveArea::History,
 
@@ -116,6 +120,10 @@ impl<'a> HeaderArea<'a> {
 
     pub fn set_line_number(&mut self, line_number: bool) {
         self.line_number = line_number;
+    }
+
+    pub fn set_banner(&mut self, banner: String) {
+        self.banner = banner;
     }
 
     pub fn set_ansi_color(&mut self, ansi_color: bool) {
@@ -148,9 +156,6 @@ impl<'a> HeaderArea<'a> {
         // init data
         self.data = vec![];
 
-        // help message
-        const HELP_MESSAGE: &str = "Display help with h key!";
-
         // HeaderArea Width
         let width = self.area.width as usize;
 
@@ -159,8 +164,7 @@ impl<'a> HeaderArea<'a> {
         let timestamp_width: usize;
         if WIDTH_TEXT_INTERVAL + POSITION_X_HELP_TEXT < width {
             command_width = width - (WIDTH_TEXT_INTERVAL + POSITION_X_HELP_TEXT);
-            timestamp_width =
-                width - (WIDTH_TEXT_INTERVAL + command_width + HELP_MESSAGE.len()) + 1;
+            timestamp_width = width - (WIDTH_TEXT_INTERVAL + command_width + self.banner.len()) + 1;
         } else {
             command_width = 0;
             timestamp_width = 0;
@@ -260,7 +264,7 @@ impl<'a> HeaderArea<'a> {
                 Style::default().fg(command_color),
             ),
             Span::styled(
-                HELP_MESSAGE.to_string(),
+                self.banner.clone(),
                 Style::default().add_modifier(Modifier::REVERSED),
             ),
             Span::styled(

--- a/src/help.rs
+++ b/src/help.rs
@@ -75,6 +75,7 @@ fn gen_help_text<'a>() -> Vec<Spans<'a>> {
         // toggle
         Spans::from(" - [c] key   ... toggle color mode."),
         Spans::from(" - [d] key   ... switch diff mode at None, Watch, Line, and Word mode. "),
+        Spans::from(" - [Bkspace] ... toggle history pane. "),
         // exit hwatch
         Spans::from(" - [q] key   ... exit hwatch."),
         // change diff
@@ -89,8 +90,8 @@ fn gen_help_text<'a>() -> Vec<Spans<'a>> {
         // change use area
         Spans::from(" - [Tab] key ... toggle current area at history or watch."),
         // filter text inpu
-        Spans::from(" - [/] key ... filter history by string."),
-        Spans::from(" - [*] key ... filter history by regex."),
+        Spans::from(" - [/] key   ... filter history by string."),
+        Spans::from(" - [*] key   ... filter history by regex."),
         Spans::from(" - [ESC] key ... unfiltering."),
     ];
 

--- a/src/help.rs
+++ b/src/help.rs
@@ -75,6 +75,7 @@ fn gen_help_text<'a>() -> Vec<Spans<'a>> {
         // toggle
         Spans::from(" - [c] key   ... toggle color mode."),
         Spans::from(" - [d] key   ... switch diff mode at None, Watch, Line, and Word mode. "),
+        Spans::from(" - [t] key   ... toggle ui (history pane & header both on/off). "),
         Spans::from(" - [Bkspace] ... toggle history pane. "),
         // exit hwatch
         Spans::from(" - [q] key   ... exit hwatch."),

--- a/src/history.rs
+++ b/src/history.rs
@@ -22,6 +22,8 @@ pub struct HistoryArea {
     ///
     pub area: tui::layout::Rect,
 
+    pub active: bool,
+
     ///
     data: Vec<Vec<History>>,
 
@@ -35,6 +37,7 @@ impl HistoryArea {
         //! new Self
         Self {
             area: tui::layout::Rect::new(0, 0, 0, 0),
+            active: false,
             data: vec![vec![History {
                 timestamp: "latest                 ".to_string(),
                 status: true,
@@ -46,6 +49,10 @@ impl HistoryArea {
 
     pub fn set_area(&mut self, area: tui::layout::Rect) {
         self.area = area;
+    }
+
+    pub fn set_active(&mut self, active: bool) {
+        self.active = active;
     }
 
     pub fn set_latest_status(&mut self, latest_status: bool) {
@@ -79,9 +86,6 @@ impl HistoryArea {
         // insert latest timestamp
         let draw_data = &self.data;
 
-        // style
-        let selected_style = Style::default().add_modifier(Modifier::REVERSED);
-
         let rows = draw_data.iter().map(|item| {
             // set table height
             let height = item
@@ -102,6 +106,11 @@ impl HistoryArea {
             Row::new(cells).height(height as u16)
         });
 
+        let base_selected_style = Style::default().add_modifier(Modifier::REVERSED);
+        let selected_style = match self.active {
+            true => base_selected_style,
+            false => base_selected_style.fg(Color::DarkGray),
+        };
         let table = Table::new(rows)
             .block(Block::default())
             .highlight_style(selected_style)

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,12 @@ fn build_app() -> clap::Command<'static> {
                 .short('N')
                 .long("line-number"),
         )
+        .arg(
+            Arg::new("no_help_banner")
+            .help("hide the \"Display help with h key\" message")
+            .long("no-help-banner")
+        )
+
         // exec flag.
         //
         .arg(
@@ -233,6 +239,7 @@ fn main() {
     let beep = matche.is_present("beep");
     let color = matche.is_present("color");
     let hide_ui = matche.is_present("no_title");
+    let hide_help_banner = matche.is_present("no_help_banner");
     let is_exec = matche.is_present("exec");
     let line_number = matche.is_present("line_number");
 
@@ -313,7 +320,8 @@ fn main() {
         .set_line_number(line_number)
         // Set diff(watch diff) in view
         .set_watch_diff(diff)
-        .set_show_ui(!hide_ui);
+        .set_show_ui(!hide_ui)
+        .set_show_help_banner(!hide_help_banner);
 
     // Set logfile
     if let Some(logfile) = logfile {

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,12 @@ fn build_app() -> clap::Command<'static> {
                 .long("differences")
                 .short('d'),
         )
+        .arg(
+            Arg::new("no_title")
+            .help("hide the UI on start. Use `t` to toggle it.")
+            .long("no-title")
+            .short('t'),
+        )
         // Enable line number mode option
         //   [--line-number,-N]
         .arg(
@@ -226,6 +232,7 @@ fn main() {
     let diff = matche.is_present("differences");
     let beep = matche.is_present("beep");
     let color = matche.is_present("color");
+    let hide_ui = matche.is_present("no_title");
     let is_exec = matche.is_present("exec");
     let line_number = matche.is_present("line_number");
 
@@ -305,7 +312,8 @@ fn main() {
         // Set line number in view
         .set_line_number(line_number)
         // Set diff(watch diff) in view
-        .set_watch_diff(diff);
+        .set_watch_diff(diff)
+        .set_show_ui(!hide_ui);
 
     // Set logfile
     if let Some(logfile) = logfile {

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,21 +259,8 @@ fn main() {
 
     // Get options flag
     // let batch = matcher.is_present("batch");
-    let diff = matcher.is_present("differences");
-    let beep = matcher.is_present("beep");
-    let mouse_events = matcher.is_present("mouse");
-    let color = matcher.is_present("color");
-    let hide_ui = matcher.is_present("no_title");
-    let hide_help_banner = matcher.is_present("no_help_banner");
-    let is_exec = matcher.is_present("exec");
-    let line_number = matcher.is_present("line_number");
 
-    // Get options value
-    let interval: f64 = matcher.value_of_t_or_exit("interval");
-
-    // let exec = matche.value_of("exec");
     let logfile = matcher.value_of("logfile");
-
     // check _logfile directory
     // TODO(blacknon): commonに移す？(ここで直書きする必要性はなさそう)
     if let Some(logfile) = logfile {
@@ -306,6 +293,7 @@ fn main() {
     // Create channel
     let (tx, rx) = unbounded();
 
+    let interval: f64 = matcher.value_of_t_or_exit("interval");
     // Start Command Thread
     {
         let m = matcher.clone();
@@ -321,7 +309,7 @@ fn main() {
             exe.command = m.values_of_lossy("command").unwrap();
 
             // Set is exec flag.
-            exe.is_exec = is_exec;
+            exe.is_exec = m.is_present("exec");
 
             // Exec command
             exe.exec_command();
@@ -338,16 +326,16 @@ fn main() {
     let mut view = view::View::new()
         // Set interval on view.header
         .set_interval(interval)
-        .set_beep(beep)
-        .set_mouse_events(mouse_events)
+        .set_beep(matcher.is_present("beep"))
+        .set_mouse_events(matcher.is_present("mouse"))
         // Set color in view
-        .set_color(color)
+        .set_color(matcher.is_present("color"))
         // Set line number in view
-        .set_line_number(line_number)
+        .set_line_number(matcher.is_present("line_number"))
         // Set diff(watch diff) in view
-        .set_watch_diff(diff)
-        .set_show_ui(!hide_ui)
-        .set_show_help_banner(!hide_help_banner);
+        .set_watch_diff(matcher.is_present("differences"))
+        .set_show_ui(!matcher.is_present("no_title"))
+        .set_show_help_banner(!matcher.is_present("no_help_banner"));
 
     // Set logfile
     if let Some(logfile) = logfile {

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,12 +39,12 @@ extern crate crossterm;
 extern crate difference;
 extern crate futures;
 extern crate heapless;
+extern crate question;
 extern crate regex;
 extern crate serde;
 extern crate shell_words;
 extern crate termwiz;
 extern crate tui;
-extern crate question;
 
 // macro crate
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,13 @@ fn build_app() -> clap::Command<'static> {
                 .short('B')
                 .long("beep"),
         )
+        // Beep option
+        //     [-B,--beep]
+        .arg(
+            Arg::new("mouse")
+                .help("enable mouse wheel support. With this option, copying text with your terminal may be harder. Try holding the Shift key.")
+                .long("mouse"),
+        )
         // Option to specify the command to be executed when the output fluctuates.
         //     [-C,--changed-command]
         .arg(
@@ -254,6 +261,7 @@ fn main() {
     // let batch = matcher.is_present("batch");
     let diff = matcher.is_present("differences");
     let beep = matcher.is_present("beep");
+    let mouse_events = matcher.is_present("mouse");
     let color = matcher.is_present("color");
     let hide_ui = matcher.is_present("no_title");
     let hide_help_banner = matcher.is_present("no_help_banner");
@@ -331,6 +339,7 @@ fn main() {
         // Set interval on view.header
         .set_interval(interval)
         .set_beep(beep)
+        .set_mouse_events(mouse_events)
         // Set color in view
         .set_color(color)
         // Set line number in view

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,7 @@ fn main() {
 
         // check _log_path exist
         if _abs_log_path.exists() {
-            println!("file {:?} is exists.", _abs_log_path);
+            println!("file {_abs_log_path:?} is exists.");
             let answer = Question::new("Log to the same file?")
                 .default(Answer::YES)
                 .show_defaults()
@@ -259,7 +259,7 @@ fn main() {
 
         // check _log_dir exist
         if !_abs_log_dir.exists() {
-            println!("directory {:?} is not exists.", _abs_log_dir);
+            println!("directory {_abs_log_dir:?} is not exists.");
             std::process::exit(1);
         }
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -344,7 +344,13 @@ fn get_watch_diff_line_with_ansi<'a>(old_line: &str, new_line: &str) -> Spans<'a
 // ==========
 
 ///
-pub fn get_line_diff<'a>(color: bool, line_number: bool, is_only_diffline: bool, old: &str, new: &str) -> Vec<Spans<'a>> {
+pub fn get_line_diff<'a>(
+    color: bool,
+    line_number: bool,
+    is_only_diffline: bool,
+    old: &str,
+    new: &str,
+) -> Vec<Spans<'a>> {
     // Create changeset
     let Changeset { diffs, .. } = Changeset::new(old, new, LINE_ENDING);
 
@@ -481,7 +487,13 @@ pub fn get_line_diff<'a>(color: bool, line_number: bool, is_only_diffline: bool,
 // ==========
 
 ///
-pub fn get_word_diff<'a>(color: bool, line_number: bool, is_only_diffline: bool, old: &str, new: &str) -> Vec<Spans<'a>> {
+pub fn get_word_diff<'a>(
+    color: bool,
+    line_number: bool,
+    is_only_diffline: bool,
+    old: &str,
+    new: &str,
+) -> Vec<Spans<'a>> {
     // Create changeset
     let Changeset { diffs, .. } = Changeset::new(old, new, LINE_ENDING);
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -74,7 +74,7 @@ pub fn get_plane_output<'a>(
 
                 if line_number && line_span.is_empty() {
                     line_span.push(Span::styled(
-                        format!("{:>wid$} | ", counter, wid = header_width),
+                        format!("{counter:>header_width$} | "),
                         Style::default().fg(Color::DarkGray),
                     ));
                 }
@@ -88,7 +88,7 @@ pub fn get_plane_output<'a>(
                 if range_count > 0 {
                     if line_number && line_span.is_empty() {
                         line_span.push(Span::styled(
-                            format!("{:>wid$} | ", counter, wid = header_width),
+                            format!("{counter:>header_width$} | "),
                             Style::default().fg(Color::DarkGray),
                         ));
                     }
@@ -121,7 +121,7 @@ pub fn get_plane_output<'a>(
 
             if line_number && last_str_line_span.is_empty() {
                 last_str_line_span.push(Span::styled(
-                    format!("{:>wid$} | ", counter, wid = header_width),
+                    format!("{counter:>header_width$} | "),
                     Style::default().fg(Color::DarkGray),
                 ));
             }
@@ -142,13 +142,13 @@ pub fn get_plane_output<'a>(
 
             if line_number {
                 line_span.push(Span::styled(
-                    format!("{:>wid$} | ", counter, wid = header_width),
+                    format!("{counter:>header_width$} | "),
                     Style::default().fg(Color::DarkGray),
                 ));
             }
 
             if color {
-                let data = ansi::bytes_to_text(format!("{}\n", l).as_bytes());
+                let data = ansi::bytes_to_text(format!("{l}\n").as_bytes());
 
                 for d in data.lines {
                     line_span.extend(d.0);
@@ -201,7 +201,7 @@ pub fn get_watch_diff<'a>(color: bool, line_number: bool, old: &str, new: &str) 
             line_data.0.insert(
                 0,
                 Span::styled(
-                    format!("{:>wid$} | ", counter, wid = header_width),
+                    format!("{counter:>header_width$} | "),
                     Style::default().fg(Color::DarkGray),
                 ),
             );
@@ -277,7 +277,7 @@ fn get_watch_diff_line<'a>(old_line: &str, new_line: &str) -> Spans<'a> {
 fn get_watch_diff_line_with_ansi<'a>(old_line: &str, new_line: &str) -> Spans<'a> {
     // If the contents are the same line.
     if old_line == new_line {
-        let new_spans = ansi::bytes_to_text(format!("{}\n", new_line).as_bytes());
+        let new_spans = ansi::bytes_to_text(format!("{new_line}\n").as_bytes());
         if let Some(spans) = new_spans.into_iter().next() {
             return spans;
         }
@@ -376,7 +376,7 @@ pub fn get_line_diff<'a>(
                     let mut data = if color {
                         // ansi color code => rs-tui colored span.
                         let mut colored_span = vec![Span::from("   ")];
-                        let colored_data = ansi::bytes_to_text(format!("{}\n", line).as_bytes());
+                        let colored_data = ansi::bytes_to_text(format!("{line}\n").as_bytes());
                         for d in colored_data.lines {
                             for x in d.0 {
                                 colored_span.push(x);
@@ -385,14 +385,14 @@ pub fn get_line_diff<'a>(
                         Spans::from(colored_span)
                     } else {
                         // to string => rs-tui span.
-                        Spans::from(format!("   {}\n", line))
+                        Spans::from(format!("   {line}\n"))
                     };
 
                     if line_number {
                         data.0.insert(
                             0,
                             Span::styled(
-                                format!("{:>wid$} | ", new_counter, wid = header_width),
+                                format!("{new_counter:>header_width$} | "),
                                 Style::default().fg(Color::DarkGray),
                             ),
                         );
@@ -415,13 +415,13 @@ pub fn get_line_diff<'a>(
                         // ansi color code => parse and delete. to rs-tui span(green).
                         let strip_str = get_ansi_strip_str(line);
                         Spans::from(Span::styled(
-                            format!("+  {}\n", strip_str),
+                            format!("+  {strip_str}\n"),
                             Style::default().fg(Color::Green),
                         ))
                     } else {
                         // to string => rs-tui span.
                         Spans::from(Span::styled(
-                            format!("+  {}\n", line),
+                            format!("+  {line}\n"),
                             Style::default().fg(Color::Green),
                         ))
                     };
@@ -430,7 +430,7 @@ pub fn get_line_diff<'a>(
                         data.0.insert(
                             0,
                             Span::styled(
-                                format!("{:>wid$} | ", new_counter, wid = header_width),
+                                format!("{new_counter:>header_width$} | "),
                                 Style::default().fg(Color::Rgb(56, 119, 120)),
                             ),
                         );
@@ -450,13 +450,13 @@ pub fn get_line_diff<'a>(
                         // ansi color code => parse and delete. to rs-tui span(green).
                         let strip_str = get_ansi_strip_str(line);
                         Spans::from(Span::styled(
-                            format!("-  {}\n", strip_str),
+                            format!("-  {strip_str}\n"),
                             Style::default().fg(Color::Red),
                         ))
                     } else {
                         // to string => rs-tui span.
                         Spans::from(Span::styled(
-                            format!("-  {}\n", line),
+                            format!("-  {line}\n"),
                             Style::default().fg(Color::Red),
                         ))
                     };
@@ -465,7 +465,7 @@ pub fn get_line_diff<'a>(
                         data.0.insert(
                             0,
                             Span::styled(
-                                format!("{:>wid$} | ", old_counter, wid = header_width),
+                                format!("{old_counter:>header_width$} | "),
                                 Style::default().fg(Color::Rgb(118, 0, 0)),
                             ),
                         );
@@ -519,7 +519,7 @@ pub fn get_word_diff<'a>(
                     let mut data = if color {
                         // ansi color code => rs-tui colored span.
                         let mut colored_span = vec![Span::from("   ")];
-                        let colored_data = ansi::bytes_to_text(format!("{}\n", line).as_bytes());
+                        let colored_data = ansi::bytes_to_text(format!("{line}\n").as_bytes());
                         for d in colored_data.lines {
                             for x in d.0 {
                                 colored_span.push(x);
@@ -528,14 +528,14 @@ pub fn get_word_diff<'a>(
                         Spans::from(colored_span)
                     } else {
                         // to string => rs-tui span.
-                        Spans::from(format!("   {}\n", line))
+                        Spans::from(format!("   {line}\n"))
                     };
 
                     if line_number {
                         data.0.insert(
                             0,
                             Span::styled(
-                                format!("{:>wid$} | ", new_counter, wid = header_width),
+                                format!("{new_counter:>header_width$} | "),
                                 Style::default().fg(Color::DarkGray),
                             ),
                         );
@@ -594,7 +594,7 @@ pub fn get_word_diff<'a>(
                         data.insert(
                             0,
                             Span::styled(
-                                format!("{:>wid$} | ", new_counter, wid = header_width),
+                                format!("{new_counter:>header_width$} | "),
                                 Style::default().fg(Color::Rgb(56, 119, 120)),
                             ),
                         );
@@ -650,7 +650,7 @@ pub fn get_word_diff<'a>(
                         data.insert(
                             0,
                             Span::styled(
-                                format!("{:>wid$} | ", old_counter, wid = header_width),
+                                format!("{old_counter:>header_width$} | "),
                                 Style::default().fg(Color::Rgb(118, 0, 0)),
                             ),
                         );
@@ -692,7 +692,7 @@ fn get_word_diff_addline<'a>(
 
     match before_diffs {
         // Change Line.
-        &Difference::Rem(ref before_diff_data) => {
+        Difference::Rem(before_diff_data) => {
             // Craete Changeset at `Addlind` and `Before Diff Data`.
             let Changeset { diffs, .. } = Changeset::new(before_diff_data, &diff_data, " ");
 
@@ -792,7 +792,7 @@ fn get_word_diff_remline<'a>(
 
     match after_diffs {
         // Change Line.
-        &Difference::Add(ref after_diffs_data) => {
+        Difference::Add(after_diffs_data) => {
             // Craete Changeset at `Addlind` and `Before Diff Data`.
             let Changeset { diffs, .. } = Changeset::new(&diff_data, after_diffs_data, " ");
 
@@ -902,7 +902,7 @@ fn get_word_diff_line_to_spans<'a>(
 // ==========
 
 /// Apply ANSI color code character by character.
-fn gen_ansi_all_set_str<'a, 'b>(text: &'a str) -> Vec<Vec<Span<'b>>> {
+fn gen_ansi_all_set_str<'b>(text: &str) -> Vec<Vec<Span<'b>>> {
     // set Result
     let mut result = vec![];
 
@@ -925,13 +925,13 @@ fn gen_ansi_all_set_str<'a, 'b>(text: &'a str) -> Vec<Vec<Span<'b>>> {
             Output::TextBlock(text) => {
                 for char in text.chars() {
                     let append_text = if !sequence_str.is_empty() {
-                        format!("{}{}{}", sequence_str, char, ansi_reset_seq_str)
+                        format!("{sequence_str}{char}{ansi_reset_seq_str}")
                     } else {
-                        format!("{}", char)
+                        format!("{char}")
                     };
 
                     // parse ansi text to tui text.
-                    let data = ansi::bytes_to_text(format!("{}\n", append_text).as_bytes());
+                    let data = ansi::bytes_to_text(format!("{append_text}\n").as_bytes());
                     if let Some(d) = data.into_iter().next() {
                         for x in d.0 {
                             processed_text.push(x);

--- a/src/view.rs
+++ b/src/view.rs
@@ -25,6 +25,7 @@ pub struct View {
     interval: f64,
     beep: bool,
     color: bool,
+    show_ui: bool,
     line_number: bool,
     watch_diff: bool,
     log_path: String,
@@ -37,6 +38,7 @@ impl View {
             interval: DEFAULT_INTERVAL,
             beep: false,
             color: false,
+            show_ui: true,
             line_number: false,
             watch_diff: false,
             log_path: "".to_string(),
@@ -55,6 +57,11 @@ impl View {
 
     pub fn set_color(mut self, color: bool) -> Self {
         self.color = color;
+        self
+    }
+
+    pub fn set_show_ui(mut self, show_ui: bool) -> Self {
+        self.show_ui = show_ui;
         self
     }
 
@@ -111,6 +118,9 @@ impl View {
 
         // set color
         app.set_ansi_color(self.color);
+
+        app.show_history(self.show_ui);
+        app.show_ui(self.show_ui);
 
         // set line_number
         app.set_line_number(self.line_number);

--- a/src/view.rs
+++ b/src/view.rs
@@ -133,7 +133,7 @@ impl View {
         terminal.show_cursor()?;
 
         if let Err(err) = res {
-            println!("{:?}", err)
+            println!("{err:?}")
         }
 
         Ok(())

--- a/src/view.rs
+++ b/src/view.rs
@@ -5,7 +5,7 @@
 use crossbeam_channel::{Receiver, Sender};
 // module
 use crossterm::{
-    // event::{DisableMouseCapture, EnableMouseCapture},
+    event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -24,6 +24,7 @@ use crate::DEFAULT_INTERVAL;
 pub struct View {
     interval: f64,
     beep: bool,
+    mouse_events: bool,
     color: bool,
     show_ui: bool,
     show_help_banner: bool,
@@ -38,6 +39,7 @@ impl View {
         Self {
             interval: DEFAULT_INTERVAL,
             beep: false,
+            mouse_events: false,
             color: false,
             show_ui: true,
             show_help_banner: true,
@@ -54,6 +56,11 @@ impl View {
 
     pub fn set_beep(mut self, beep: bool) -> Self {
         self.beep = beep;
+        self
+    }
+
+    pub fn set_mouse_events(mut self, mouse_events: bool) -> Self {
+        self.mouse_events = mouse_events;
         self
     }
 
@@ -95,11 +102,10 @@ impl View {
         // Setup Terminal
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        execute!(
-            stdout,
-            EnterAlternateScreen,
-            // EnableMouseCapture,
-        )?;
+        execute!(stdout, EnterAlternateScreen)?;
+        if self.mouse_events {
+            execute!(stdout, EnableMouseCapture)?;
+        }
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
         let _ = terminal.clear();
@@ -146,7 +152,7 @@ impl View {
         execute!(
             terminal.backend_mut(),
             LeaveAlternateScreen,
-            // DisableMouseCapture
+            DisableMouseCapture
         )?;
         terminal.show_cursor()?;
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -53,7 +53,6 @@ impl View {
         self
     }
 
-
     pub fn set_color(mut self, color: bool) -> Self {
         self.color = color;
         self

--- a/src/view.rs
+++ b/src/view.rs
@@ -26,6 +26,7 @@ pub struct View {
     beep: bool,
     color: bool,
     show_ui: bool,
+    show_help_banner: bool,
     line_number: bool,
     watch_diff: bool,
     log_path: String,
@@ -39,6 +40,7 @@ impl View {
             beep: false,
             color: false,
             show_ui: true,
+            show_help_banner: true,
             line_number: false,
             watch_diff: false,
             log_path: "".to_string(),
@@ -62,6 +64,11 @@ impl View {
 
     pub fn set_show_ui(mut self, show_ui: bool) -> Self {
         self.show_ui = show_ui;
+        self
+    }
+
+    pub fn set_show_help_banner(mut self, show_help_banner: bool) -> Self {
+        self.show_help_banner = show_help_banner;
         self
     }
 
@@ -121,6 +128,7 @@ impl View {
 
         app.show_history(self.show_ui);
         app.show_ui(self.show_ui);
+        app.show_help_banner(self.show_help_banner);
 
         // set line_number
         app.set_line_number(self.line_number);

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -57,9 +57,7 @@ impl<'a> WatchArea<'a> {
 
     ///
     pub fn scroll_up(&mut self, num: i16) {
-        if 0 <= self.position - num {
-            self.position -= num
-        }
+        self.position = std::cmp::max(0, self.position - num);
     }
 
     // TODO: 折返しによって発生する行数差分の計算方法が思いつかないため、思いついたら対応を追加する。(うまく取得が出来ない)
@@ -67,9 +65,6 @@ impl<'a> WatchArea<'a> {
     pub fn scroll_down(&mut self, num: i16) {
         // get area data size
         let data_size = self.data.len() as i16;
-
-        if data_size > self.position + num {
-            self.position += num
-        }
+        self.position = std::cmp::min(self.position + num, data_size - 1);
     }
 }


### PR DESCRIPTION
This introduces a `--mouse` option that captures mouse events again. The only mouse events supported is
the scroll wheel, which always scrolls the main window. (I'm not sure if scrolling history with the mouse wheel is useful).

Also cleans up `main.rs` a little bit.

Includes all the other PRs for simplicity, let me know if you prefer for me to split them or rebase.