### PR TITLE
Remove unused manifest key from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 keywords = ["watch", "command", "monitoring"]
 license-file = "LICENSE"
 name = "hwatch"
-opt-level = 3
 repository = "https://github.com/blacknon/hwatch"
 version = "0.3.7"
 


### PR DESCRIPTION
This PR removes the following warning which occurs during `cargo check`:

```
warning: unused manifest key: package.opt-level
```

If you would like to specify an optimization level for the debug profile, you should do the following:

```toml
[profile.dev]
opt-level = 3
```

See: https://doc.rust-lang.org/book/ch14-01-release-profiles.html

I can submit a separate PR for that 🐻 LMK!

