### PR TITLE
Add AUR instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ That records the result of command execution and can display it history and diff
 
     sudo port install hwatch
 
+### Arch Linux (AUR)
+
+    paru -S hwatch
+
 ### Cargo Install
 
     cargo install hwatch


### PR DESCRIPTION
I created the following packages for installing `hwatch` on Arch Linux:

- https://aur.archlinux.org/packages/hwatch
- https://aur.archlinux.org/packages/hwatch-git

This PR updates README.md about installation instructions 🐻
