### PR TITLE
Watch diff: fix display: change space from delete to nbsp

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -226,9 +226,9 @@ fn get_watch_diff_line<'a>(old_line: &str, new_line: &str) -> Spans<'a> {
     let mut old_line_chars: Vec<char> = old_line.chars().collect();
     let mut new_line_chars: Vec<char> = new_line.chars().collect();
 
-    // 007f ... delete char.
-    // NOTE: Use hidden characters to branch processing because tui-rs skips space characters.
-    let space: char = '\u{007f}';
+    // 00a0 ... non-breaking space.
+    // NOTE: Used because tui-rs skips regular space characters.
+    let space: char = '\u{00a0}';
     let max_char = cmp::max(old_line_chars.len(), new_line_chars.len());
 
     let mut _result = vec![];
@@ -267,7 +267,7 @@ fn get_watch_diff_line<'a>(old_line: &str, new_line: &str) -> Spans<'a> {
     }
 
     // last char
-    // NOTE: Added hidden characters as tui-rs forces trimming of end-of-line spaces.
+    // NOTE: NBSP used as tui-rs trims regular spaces.
     _result.push(Span::styled(space.to_string(), Style::default()));
 
     Spans::from(_result)
@@ -296,9 +296,9 @@ fn get_watch_diff_line_with_ansi<'a>(old_line: &str, new_line: &str) -> Spans<'a
         // break;
     }
 
-    // 007f ... delete char.
-    // NOTE: Use hidden characters to branch processing because tui-rs skips space characters.
-    let space = '\u{007f}'.to_string();
+    // 00a0 ... non-breaking space.
+    // NOTE: Used because tui-rs skips regular space characters.
+    let space = '\u{00a0}'.to_string();
     let max_span = cmp::max(old_spans.len(), new_spans.len());
     //
     let mut _result = vec![];


### PR DESCRIPTION
Changes the space character used for padding and as a last character from the delete character (U+007F) to nbsp (U+00A0).

The delete character causes some issues when appended as the last character by in the Watch diff mode (the last character from the date is seen), changing the space character to a nbsp fixes this.

Fixes blacknon/hwatch#88.