### PR TITLE
Live update interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ watch window keybind
 | <kbd>F1</kbd>  | only stdout print.
 | <kbd>F2</kbd>  | only stderr print.
 | <kbd>F3</kbd>  | print output.
+| <kbd>+</kbd>   | increase interval.
+| <kbd>-</kbd>   | decrease interval.
 | <kbd>Tab</kbd> | toggle select screen(history/watch).
 | <kbd>/</kbd>   | filter history by string.
 | <kbd>*</kbd>   | filter history by regex.

--- a/man/man.md
+++ b/man/man.md
@@ -130,6 +130,13 @@ F3
 
 :   Display *Stdout* and *Stderr*.
 
++
+
+:   Increase interval by .5 seconds.
+
+-
+
+:   Decrease interval by .5 seconds (As long as it's positive).
 
 Tab
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,14 +19,14 @@ use tui::{
 use std::thread;
 
 // local module
-use crate::{common::logging_result, Interval};
 use crate::event::AppEvent;
-use crate::exec::{exec_after_command,CommandResult};
+use crate::exec::{exec_after_command, CommandResult};
 use crate::header::HeaderArea;
 use crate::help::HelpWindow;
 use crate::history::{History, HistoryArea};
 use crate::output;
 use crate::watch::WatchArea;
+use crate::{common::logging_result, Interval};
 
 // local const
 use crate::HISTORY_WIDTH;
@@ -174,7 +174,7 @@ impl<'a> App<'a> {
             results: HashMap::new(),
             interval: interval.clone(),
 
-            header_area: HeaderArea::new(interval.read().unwrap().clone()),
+            header_area: HeaderArea::new(*interval.read().unwrap()),
             history_area: HistoryArea::new(),
             watch_area: WatchArea::new(),
 
@@ -391,7 +391,7 @@ impl<'a> App<'a> {
     }
 
     ///
-    pub fn set_after_command(&mut self, command: String){
+    pub fn set_after_command(&mut self, command: String) {
         self.after_command = command;
     }
 
@@ -582,9 +582,14 @@ impl<'a> App<'a> {
             let after_result = _result.clone();
 
             {
-                thread::spawn(move|| {
-                    let _ = exec_after_command("sh -c".to_string(),after_command.clone(),before_result,after_result);
-            });
+                thread::spawn(move || {
+                    exec_after_command(
+                        "sh -c".to_string(),
+                        after_command.clone(),
+                        before_result,
+                        after_result,
+                    );
+                });
             }
         }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -167,8 +167,8 @@ pub struct ExecuteAfterResultData {
 
 pub fn exec_after_command(shell_command: String, after_command: String, before_result: CommandResult, after_result: CommandResult) {
     let result_data = ExecuteAfterResultData {
-        before_result: before_result,
-        after_result: after_result,
+        before_result,
+        after_result,
     };
 
     // create json_data
@@ -232,7 +232,7 @@ fn create_exec_cmd_args(is_exec: bool, shell_command: String, command: String) -
         }
     }
 
-    return exec_commands;
+    exec_commands
 
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -18,9 +18,6 @@ use tui::{
 use crate::app::{ActiveArea, DiffMode, InputMode, OutputMode};
 use crate::exec::CommandResult;
 
-// local const
-use crate::DEFAULT_INTERVAL;
-
 //const
 const POSITION_X_HELP_TEXT: usize = 53;
 const WIDTH_TEXT_INTERVAL: usize = 19;
@@ -78,11 +75,11 @@ pub struct HeaderArea<'a> {
 
 /// Header Area Object Trait
 impl<'a> HeaderArea<'a> {
-    pub fn new() -> Self {
+    pub fn new(interval: f64) -> Self {
         Self {
             area: tui::layout::Rect::new(0, 0, 0, 0),
 
-            interval: DEFAULT_INTERVAL,
+            interval,
 
             command: "".to_string(),
             timestamp: "".to_string(),

--- a/src/help.rs
+++ b/src/help.rs
@@ -74,6 +74,7 @@ fn gen_help_text<'a>() -> Vec<Spans<'a>> {
         Spans::from(" - [h] key   ... show this help message."),
         // toggle
         Spans::from(" - [c] key   ... toggle color mode."),
+        Spans::from(" - [n] key   ... toggle line number."),
         Spans::from(" - [d] key   ... switch diff mode at None, Watch, Line, and Word mode. "),
         Spans::from(" - [t] key   ... toggle ui (history pane & header both on/off). "),
         Spans::from(" - [Bkspace] ... toggle history pane. "),
@@ -88,6 +89,9 @@ fn gen_help_text<'a>() -> Vec<Spans<'a>> {
         Spans::from(" - [F1] key  ... change output mode as stdout."),
         Spans::from(" - [F2] key  ... change output mode as stderr."),
         Spans::from(" - [F3] key  ... change output mode as output(stdout/stderr set.)"),
+        // change interval
+        Spans::from(" - [+] key ... Increase interval by 1 second."),
+        Spans::from(" - [-] key ... Decrease interval by 1 second."),
         // change use area
         Spans::from(" - [Tab] key ... toggle current area at history or watch."),
         // filter text inpu

--- a/src/help.rs
+++ b/src/help.rs
@@ -90,8 +90,8 @@ fn gen_help_text<'a>() -> Vec<Spans<'a>> {
         Spans::from(" - [F2] key  ... change output mode as stderr."),
         Spans::from(" - [F3] key  ... change output mode as output(stdout/stderr set.)"),
         // change interval
-        Spans::from(" - [+] key ... Increase interval by 1 second."),
-        Spans::from(" - [-] key ... Decrease interval by 1 second."),
+        Spans::from(" - [+] key ... Increase interval by .5 seconds."),
+        Spans::from(" - [-] key ... Decrease interval by .5 seconds."),
         // change use area
         Spans::from(" - [Tab] key ... toggle current area at history or watch."),
         // filter text inpu

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,9 +289,8 @@ fn main() {
     // Create channel
     let (tx, rx) = unbounded();
 
-    // interval = matcher.value_of_t_or_exit("interval");
     let override_interval = matcher.value_of_t("interval").unwrap_or(DEFAULT_INTERVAL);
-    let interval = Interval::new(RwLock::new(override_interval));
+    let interval = Interval::new(override_interval.into());
 
     // Start Command Thread
     {
@@ -317,7 +316,7 @@ fn main() {
             // Exec command
             exe.exec_command();
 
-            let sleep_interval = interval.read().unwrap().clone();
+            let sleep_interval = *interval.read().unwrap();
             std::thread::sleep(Duration::from_secs_f64(sleep_interval));
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ use clap::{AppSettings, Arg, Command};
 use question::{Answer, Question};
 use std::env::args;
 use std::path::Path;
+use std::sync::{Arc, RwLock};
 // use std::sync::mpsc::channel;
 use crossbeam_channel::unbounded;
 use std::thread;
@@ -75,6 +76,7 @@ mod watch;
 pub const DEFAULT_INTERVAL: f64 = 2.0;
 pub const HISTORY_WIDTH: u16 = 25;
 pub const SHELL_COMMAND_EXECCMD: &str = "{COMMAND}";
+type Interval = Arc<RwLock<f64>>;
 
 // const at Windows
 #[cfg(windows)]
@@ -287,29 +289,36 @@ fn main() {
     // Create channel
     let (tx, rx) = unbounded();
 
-    let interval: f64 = matcher.value_of_t_or_exit("interval");
+    // interval = matcher.value_of_t_or_exit("interval");
+    let override_interval = matcher.value_of_t("interval").unwrap_or(DEFAULT_INTERVAL);
+    let interval = Interval::new(RwLock::new(override_interval));
+
     // Start Command Thread
     {
         let m = matcher.clone();
         let tx = tx.clone();
+        let shell_command = m.value_of("shell_command").unwrap().to_string();
+        let command = m.values_of_lossy("command").unwrap();
+        let is_exec = m.is_present("exec");
+        let interval = interval.clone();
         let _ = thread::spawn(move || loop {
             // Create cmd..
             let mut exe = exec::ExecuteCommand::new(tx.clone());
 
             // Set shell command
-            exe.shell_command = m.value_of("shell_command").unwrap().to_string();
+            exe.shell_command = shell_command.clone();
 
             // Set command
-            exe.command = m.values_of_lossy("command").unwrap();
+            exe.command = command.clone();
 
             // Set is exec flag.
-            exe.is_exec = m.is_present("exec");
+            exe.is_exec = is_exec;
 
             // Exec command
             exe.exec_command();
 
-            // sleep interval
-            std::thread::sleep(Duration::from_secs_f64(interval));
+            let sleep_interval = interval.read().unwrap().clone();
+            std::thread::sleep(Duration::from_secs_f64(sleep_interval));
         });
     }
 
@@ -317,7 +326,7 @@ fn main() {
     // if !batch {
     // is watch mode
     // Create view
-    let mut view = view::View::new()
+    let mut view = view::View::new(interval.clone())
         // Set interval on view.header
         .set_interval(interval)
         .set_beep(matcher.is_present("beep"))


### PR DESCRIPTION
Hi!

Thanks again for such a useful tool. I often find myself using hwatch to ping a server every few seconds to find differences. Then I feel guilty for hitting the server too much and restart the command with a higher interval. But that also means I lose the history of the previous commands. I wondered what it would be like to have the interval be a runtime variable that could be updated.

This PR turns the const DEFAULT_INTERVAL (or passed in cli argument "interval") into the Arc (https://doc.rust-lang.org/std/sync/struct.Arc.html) Interval. I made it a new type for ease of use, then we can just clone it and share the reference by multiple places throughout the code. In particular, 

**main.rs** -> This has the update thread time. Each loop it rereads the current global Interval and starts a new timer
**view.rs** -> This is what builds the App, so I passed it along
**app.rs** -> This is where the interval can be increased and decreased
**headers.rs** -> This draws the number to the screen, so it just has a f64, but has been updated from pointing directly at DEFAULT_INTERVAL

The rest of the changes are docs and clippy errors. (I noticed `n` for  toggling line numbers was missing from the help menu, so I added that, too)

Happy to update things if you see a cleaner pattern but still want to accept the PR in some fashion.

Thanks!
Brian
