### PR TITLE
feat: mouse support keybind

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -8,5 +8,6 @@ pub enum AppEvent {
     OutputUpdate(CommandResult),
     TerminalEvent(crossterm::event::Event),
     Redraw,
+    ToggleMouseEvents,
     Exit,
 }

--- a/src/help.rs
+++ b/src/help.rs
@@ -78,7 +78,7 @@ fn gen_help_text<'a>() -> Vec<Spans<'a>> {
         Spans::from(" - [d] key   ... switch diff mode at None, Watch, Line, and Word mode. "),
         Spans::from(" - [t] key   ... toggle ui (history pane & header both on/off). "),
         Spans::from(" - [Bkspace] ... toggle history pane. "),
-        Spans::from(" - [m] key   ... toggle mouse wheel support. With this option, copying text with your terminal may be harder. Try holding the Shift key"),
+        Spans::from(" - [m] key   ... toggle mouse wheel support. With this option, copying text with your terminal may be harder. Try holding the Shift key."),
         // exit hwatch
         Spans::from(" - [q] key   ... exit hwatch."),
         // change diff

--- a/src/help.rs
+++ b/src/help.rs
@@ -78,6 +78,7 @@ fn gen_help_text<'a>() -> Vec<Spans<'a>> {
         Spans::from(" - [d] key   ... switch diff mode at None, Watch, Line, and Word mode. "),
         Spans::from(" - [t] key   ... toggle ui (history pane & header both on/off). "),
         Spans::from(" - [Bkspace] ... toggle history pane. "),
+        Spans::from(" - [m] key   ... toggle mouse wheel support. With this option, copying text with your terminal may be harder. Try holding the Shift key"),
         // exit hwatch
         Spans::from(" - [q] key   ... exit hwatch."),
         // change diff
@@ -94,7 +95,7 @@ fn gen_help_text<'a>() -> Vec<Spans<'a>> {
         Spans::from(" - [-] key ... Decrease interval by .5 seconds."),
         // change use area
         Spans::from(" - [Tab] key ... toggle current area at history or watch."),
-        // filter text inpu
+        // filter text input
         Spans::from(" - [/] key   ... filter history by string."),
         Spans::from(" - [*] key   ... filter history by regex."),
         Spans::from(" - [ESC] key ... unfiltering."),

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,14 +7,13 @@ use ansi_parser::{AnsiParser, AnsiSequence, Output};
 use difference::{Changeset, Difference};
 use heapless::consts::*;
 use regex::Regex;
+use std::borrow::Cow;
 use std::cmp;
+use std::fmt::Write;
 use tui::{
     style::{Color, Modifier, Style},
     text::{Span, Spans},
 };
-use std::borrow::Cow;
-use std::fmt::Write;
-
 
 // local const
 use crate::ansi;
@@ -69,10 +68,7 @@ fn expand_line_tab(data: &str, tab_size: u16) -> String {
         result_vec.push(l);
     }
 
-    let rslt = result_vec.join("\n");
-
-    return rslt
-
+    result_vec.join("\n")
 }
 
 // plane output
@@ -229,7 +225,13 @@ pub fn get_plane_output<'a>(
 // ==========
 
 ///
-pub fn get_watch_diff<'a>(color: bool, line_number: bool, old: &str, new: &str, tab_size: u16) -> Vec<Spans<'a>> {
+pub fn get_watch_diff<'a>(
+    color: bool,
+    line_number: bool,
+    old: &str,
+    new: &str,
+    tab_size: u16,
+) -> Vec<Spans<'a>> {
     //
     let old_text = &expand_line_tab(old, tab_size);
     let new_text = &expand_line_tab(new, tab_size);
@@ -258,7 +260,6 @@ pub fn get_watch_diff<'a>(color: bool, line_number: bool, old: &str, new: &str, 
 
         let old_line = old_vec[i];
         let new_line = new_vec[i];
-
 
         let mut line_data = match color {
             false => get_watch_diff_line(&old_line, &new_line),
@@ -418,7 +419,7 @@ pub fn get_line_diff<'a>(
     is_only_diffline: bool,
     old: &str,
     new: &str,
-    tab_size: u16
+    tab_size: u16,
 ) -> Vec<Spans<'a>> {
     let old_text = &expand_line_tab(old, tab_size);
     let new_text = &expand_line_tab(new, tab_size);
@@ -568,7 +569,7 @@ pub fn get_word_diff<'a>(
     is_only_diffline: bool,
     old: &str,
     new: &str,
-    tab_size: u16
+    tab_size: u16,
 ) -> Vec<Spans<'a>> {
     let old_text = &expand_line_tab(old, tab_size);
     let new_text = &expand_line_tab(new, tab_size);

--- a/src/view.rs
+++ b/src/view.rs
@@ -9,7 +9,11 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use std::{error::Error, io, sync::{Arc, RwLock}};
+use std::{
+    error::Error,
+    io,
+    sync::{Arc, RwLock},
+};
 use tui::{backend::CrosstermBackend, Terminal};
 
 // local module
@@ -139,7 +143,7 @@ impl View {
         }
 
         // Create App
-        let mut app = App::new(tx, rx, self.interval.clone());
+        let mut app = App::new(tx, rx, self.interval.clone(), self.mouse_events);
 
         // set after command
         app.set_after_command(self.after_command.clone());


### PR DESCRIPTION
This PR adds support for toggling the mouse events (`--mouse`CLI flag) inside the main view via `m` key binding.