### PR TITLE
add bash completion and RPM Spec file

### DIFF
--- a/completion/bash/hwatch-completion.bash
+++ b/completion/bash/hwatch-completion.bash
@@ -1,0 +1,14 @@
+_hwatch() {
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="-b --batch -B --beep --border --with-scrollbar --mouse -c --color -r --reverse -C --compress -t --no-title -N --line-number --no-help-banner -x --exec -O --diff-output-only -A --aftercommand -l --logfile -s --shell -n --interval -L --limit --tab-size -d --differences -o --output -K --keymap -h --help -V --version"
+
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+}
+
+complete -F _hwatch hwatch

--- a/hwatch.spec
+++ b/hwatch.spec
@@ -1,12 +1,11 @@
 Name:           hwatch
 Version:        0.3.14
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A modern alternative to the watch command, records the differences in execution results and can check this differences at after.
 URL:            https://github.com/blacknon/hwatch/
 License:        MIT
 Source0:        https://github.com/blacknon/hwatch/archive/refs/tags/%{version}.tar.gz
 
-# BuildRequires: List all packages required to build the software
 BuildRequires:  git
 BuildRequires:  python3
 BuildRequires:  curl
@@ -35,9 +34,10 @@ Features:
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 export PATH="$PATH:$HOME/.cargo/bin"
 $HOME/.cargo/bin/cargo build --release --all-features
+strip target/release/%{name} 
 
 %install
-# You may need to adjust paths and permissions as necessary
+install -D -m 644 completion/bash/hwatch-completion.bash %{buildroot}/etc/bash_completion.d/%{name}.bash
 install -D -m 755 target/release/%{name} %{buildroot}/usr/bin/%{name}
 install -D -m 644 LICENSE %{buildroot}/usr/share/licenses/%{name}/LICENSE
 install -D -m 644 README.md %{buildroot}/usr/share/doc/%{name}/README.md
@@ -46,11 +46,14 @@ install -D -m 644 README.md %{buildroot}/usr/share/doc/%{name}/README.md
 $HOME/.cargo/bin/cargo test --release --locked --all-features
 
 %files
-# List all installed files and directories
 %license LICENSE
 %doc README.md
 /usr/bin/%{name}
+/etc/bash_completion.d/%{name}.bash
 
 %changelog
+* Mon May 13 2024 Danie de Jager - 0.3.14-2
+ - strip binary
+ - add bash completion
 * Mon May 13 2024 Danie de Jager - 0.3.14-1
-- Initial version
+ - Initial version

--- a/hwatch.spec
+++ b/hwatch.spec
@@ -1,0 +1,56 @@
+Name:           hwatch
+Version:        0.3.14
+Release:        1%{?dist}
+Summary:        A modern alternative to the watch command, records the differences in execution results and can check this differences at after.
+URL:            https://github.com/blacknon/hwatch/
+License:        MIT
+Source0:        https://github.com/blacknon/hwatch/archive/refs/tags/%{version}.tar.gz
+
+# BuildRequires: List all packages required to build the software
+BuildRequires:  git
+BuildRequires:  python3
+BuildRequires:  curl
+BuildRequires:  gcc
+
+%define debug_package %{nil}
+
+%description
+hwatch is a alternative watch command. That records the result of command execution and can display it history and diffs.
+
+Features:
+* Can keep the history when the difference, occurs and check it later.
+* Can check the difference in the history. The display method can be changed in real time.
+* Can output the execution result as log (json format).
+* Custom keymaps are available.
+* Support ANSI color code.
+* Execution result can be scroll.
+* Not only as a TUI application, but also to have the differences output as standard output.
+* If a difference occurs, you can have the specified command additionally executed.
+
+%prep
+%setup -q
+
+%build
+# Install Rust using curl
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+export PATH="$PATH:$HOME/.cargo/bin"
+$HOME/.cargo/bin/cargo build --release --all-features
+
+%install
+# You may need to adjust paths and permissions as necessary
+install -D -m 755 target/release/%{name} %{buildroot}/usr/bin/%{name}
+install -D -m 644 LICENSE %{buildroot}/usr/share/licenses/%{name}/LICENSE
+install -D -m 644 README.md %{buildroot}/usr/share/doc/%{name}/README.md
+
+%check
+$HOME/.cargo/bin/cargo test --release --locked --all-features
+
+%files
+# List all installed files and directories
+%license LICENSE
+%doc README.md
+/usr/bin/%{name}
+
+%changelog
+* Mon May 13 2024 Danie de Jager - 0.3.14-1
+- Initial version

--- a/hwatch.spec
+++ b/hwatch.spec
@@ -1,7 +1,7 @@
 Name:           hwatch
 Version:        0.3.14
 Release:        2%{?dist}
-Summary:        A modern alternative to the watch command, records the differences in execution results and can check this differences at after.
+Summary:        A modern alternative to the 'watch' command, it records differences in execution results and allows for examination of these differences afterward.
 URL:            https://github.com/blacknon/hwatch/
 License:        MIT
 Source0:        https://github.com/blacknon/hwatch/archive/refs/tags/%{version}.tar.gz
@@ -14,7 +14,7 @@ BuildRequires:  gcc
 %define debug_package %{nil}
 
 %description
-hwatch is a alternative watch command. That records the result of command execution and can display it history and diffs.
+hwatch is a alternative watch command. Records the results of command execution that can display its history and differences.
 
 Features:
 * Can keep the history when the difference, occurs and check it later.
@@ -37,7 +37,7 @@ $HOME/.cargo/bin/cargo build --release --all-features
 strip target/release/%{name} 
 
 %install
-install -D -m 644 completion/bash/hwatch-completion.bash %{buildroot}/etc/bash_completion.d/%{name}.bash
+install -D -m 644 completion/bash/%{name}-completion.bash %{buildroot}/etc/bash_completion.d/%{name}.bash
 install -D -m 755 target/release/%{name} %{buildroot}/usr/bin/%{name}
 install -D -m 644 LICENSE %{buildroot}/usr/share/licenses/%{name}/LICENSE
 install -D -m 644 README.md %{buildroot}/usr/share/doc/%{name}/README.md


### PR DESCRIPTION
1. added SPEC File which can be used to build RPM files
2. added rudimentary bash completion script.
3. changed wording on the SPEC Description and summary.