### PR TITLE
Specify metadata for `cargo binstall hwatch` to use official binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,7 @@ serde_json = "1.0.114"
 shell-words = "1.1.0"
 similar = {version = "2.5.0", features = ["serde", "unicode", "text", "inline", "bytes"]}
 termwiz = "0.22.0"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ version }.{ target }.{ archive-format }"
+bin-dir = "bin/{ bin }{ binary-ext }"


### PR DESCRIPTION
Previously, for users of [`cargo
binstall`](https://github.com/cargo-bins/cargo-binstall), `cargo binstall hwatch` either failed or used a binary from a third party (QuickInstall).

This sets up the [metadata] to point `cargo binstall` to the official `hwatch` binaries from the GitHub release. This should make `cargo binstall hwatch` smoothly supported for platforms with official binaries *after the next release* (when `Cargo.toml` with this metadata is published to crates.io).

I tested this on aarch64-apple-darwin, it should work for all Linux and Darwin binaries. The way to test this is to check out this PR and run

    cargo binstall hwatch --verbose --dry-run --manifest-path .  --strategies crate-meta-data 

from the repo root. 

This currently does NOT work on Windows because the official windows binary archive places the executable in
`target/x86_64-pc-windows-gnu/release/hwatch.exe` while archives for all other platforms use `bin/hwatch`. This should start working if the official binary archive is changed to contain `bin/hwatch.exe`.

[metadata]: https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md