### PR TITLE
Don't show diff on first command result

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -475,7 +475,7 @@ impl<'a> App<'a> {
         let dest: &CommandResult = &results[&target_dst].command_result;
 
         // set old text(text_src)
-        let mut src = &CommandResult::default();
+        let mut src = dest;
         if previous_dst > 0 {
             src = &results[&previous_dst].command_result;
         }


### PR DESCRIPTION
Currently command result is initialized as empty which means that the first diff shows everything as added. With this change the no changes are shown on the first command result.