### PR TITLE
Update all shell completions

### DIFF
--- a/completion/bash/hwatch-completion.bash
+++ b/completion/bash/hwatch-completion.bash
@@ -1,14 +1,132 @@
 _hwatch() {
-    local cur prev opts
+    local i cur prev opts cmd
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="-b --batch -B --beep --border --with-scrollbar --mouse -c --color -r --reverse -C --compress -t --no-title -N --line-number --no-help-banner -x --exec -O --diff-output-only -A --aftercommand -l --logfile -s --shell -n --interval -L --limit --tab-size -d --differences -o --output -K --keymap -h --help -V --version"
+    cmd=""
+    opts=""
 
-    if [[ ${cur} == -* ]]; then
-        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-        return 0
-    fi
+    for i in ${COMP_WORDS[@]}
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="hwatch"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        hwatch)
+            opts="-b -B -c -r -C -t -N -x -O -A -l -s -n -L -d -o -K -h -V --batch --beep --border --with-scrollbar --mouse --color --reverse --compress --no-title --line-number --no-help-banner --exec --diff-output-only --aftercommand --logfile --shell --interval --limit --tab-size --differences --output --keymap --help --version [command]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --aftercommand)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -A)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --logfile)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                -l)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --shell)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -s)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --interval)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -n)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --limit)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -L)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --tab-size)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --differences)
+                    COMPREPLY=($(compgen -W "none watch line word" -- "${cur}"))
+                    return 0
+                    ;;
+                -d)
+                    COMPREPLY=($(compgen -W "none watch line word" -- "${cur}"))
+                    return 0
+                    ;;
+                --output)
+                    COMPREPLY=($(compgen -W "output stdout stderr" -- "${cur}"))
+                    return 0
+                    ;;
+                -o)
+                    COMPREPLY=($(compgen -W "output stdout stderr" -- "${cur}"))
+                    return 0
+                    ;;
+                --keymap)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -K)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
 }
 
-complete -F _hwatch hwatch
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _hwatch -o nosort -o bashdefault -o default hwatch
+else
+    complete -F _hwatch -o bashdefault -o default hwatch
+fi

--- a/completion/fish/hwatch.fish
+++ b/completion/fish/hwatch.fish
@@ -1,7 +1,24 @@
-complete -c hwatch -s h -l help -d 'show help'
-complete -c hwatch -s V -l version -d 'show version'
+complete -c hwatch -s A -l aftercommand -d 'Executes the specified command if the output changes. Information about changes is stored in json format in environment variable ${HWATCH_DATA}.' -r -f -a "(__fish_complete_command)"
+complete -c hwatch -s l -l logfile -d 'logging file' -r -F
+complete -c hwatch -s s -l shell -d 'shell to use at runtime. can  also insert the command to the location specified by {COMMAND}.' -r -f -a "(__fish_complete_command)"
+complete -c hwatch -s n -l interval -d 'seconds to wait between updates' -r
+complete -c hwatch -s L -l limit -d 'Set the number of history records to keep. only work in watch mode. Set `0` for unlimited recording. (default: 5000)' -r
+complete -c hwatch -l tab-size -d 'Specifying tab display size' -r
+complete -c hwatch -s d -l differences -d 'highlight changes between updates' -r -f -a "{none\t'',watch\t'',line\t'',word\t''}"
+complete -c hwatch -s o -l output -d 'Select command output.' -r -f -a "{output\t'',stdout\t'',stderr\t''}"
+complete -c hwatch -s K -l keymap -d 'Add keymap' -r
+complete -c hwatch -s b -l batch -d 'output exection results to stdout'
+complete -c hwatch -s B -l beep -d 'beep if command has a change result'
+complete -c hwatch -l border -d 'Surround each pane with a border frame'
+complete -c hwatch -l with-scrollbar -d 'When the border option is enabled, display scrollbar on the right side of watch pane.'
+complete -c hwatch -l mouse -d 'enable mouse wheel support. With this option, copying text with your terminal may be harder. Try holding the Shift key.'
 complete -c hwatch -s c -l color -d 'interpret ANSI color and style sequences'
-complete -c hwatch -s d -l differences -d 'highlight changes between updates'
-complete -c hwatch -s l -l logfile -x -d 'logging file'
-complete -c hwatch -s n -l interval -x -d 'seconds to wait between updates'
-complete -c hwatch -xa '(__fish_complete_subcommand -- -n --interval)' -d Command
+complete -c hwatch -s r -l reverse -d 'display text upside down.'
+complete -c hwatch -s C -l compress -d 'Compress data in memory. Note: If the output of the command is small, you may not get the desired effect.'
+complete -c hwatch -s t -l no-title -d 'hide the UI on start. Use `t` to toggle it.'
+complete -c hwatch -s N -l line-number -d 'show line number'
+complete -c hwatch -l no-help-banner -d 'hide the "Display help with h key" message'
+complete -c hwatch -s x -l exec -d 'Run the command directly, not through the shell. Much like the `-x` option of the watch command.'
+complete -c hwatch -s O -l diff-output-only -d 'Display only the lines with differences during `line` diff and `word` diff.'
+complete -c hwatch -s h -l help -d 'Print help'
+complete -c hwatch -s V -l version -d 'Print version'

--- a/completion/zsh/_hwatch
+++ b/completion/zsh/_hwatch
@@ -1,12 +1,75 @@
 #compdef hwatch
+
+autoload -U is-at-least
+
 _hwatch() {
-    _arguments -s \
-        '(-h --help)'{-h,--help}'[show help]' \
-        '(-V --version)'{-V,--version}'[show version]' \
-        '(-c --color)'{-c,--color}'[interpret ANSI color and style sequences]' \
-        '(-d --differences)'{-d,--differences}'[highlight changes between updates]' \
-        '(-l --logfile)'{-l,--logfile}'+[logging file]:include file:_files' \
-        '(-n --interval)'{-n,--interval}'[seconds to wait between updates]:num:_values num 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20' \
-        '(-):command: _command_names' \
-        '*::args: _normal'
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" : \
+'*-A+[Executes the specified command if the output changes. Information about changes is stored in json format in environment variable \${HWATCH_DATA}.]: :_cmdstring' \
+'*--aftercommand=[Executes the specified command if the output changes. Information about changes is stored in json format in environment variable \${HWATCH_DATA}.]: :_cmdstring' \
+'*-l+[logging file]' \
+'*--logfile=[logging file]' \
+'*-s+[shell to use at runtime. can  also insert the command to the location specified by {COMMAND}.]: :_cmdstring' \
+'*--shell=[shell to use at runtime. can  also insert the command to the location specified by {COMMAND}.]: :_cmdstring' \
+'*-n+[seconds to wait between updates]: : ' \
+'*--interval=[seconds to wait between updates]: : ' \
+'-L+[Set the number of history records to keep. only work in watch mode. Set \`0\` for unlimited recording. (default\: 5000)]: : ' \
+'--limit=[Set the number of history records to keep. only work in watch mode. Set \`0\` for unlimited recording. (default\: 5000)]: : ' \
+'*--tab-size=[Specifying tab display size]: : ' \
+'*-d+[highlight changes between updates]' \
+'*--differences=[highlight changes between updates]' \
+'*-o+[Select command output.]' \
+'*--output=[Select command output.]' \
+'*-K+[Add keymap]: : ' \
+'*--keymap=[Add keymap]: : ' \
+'-b[output exection results to stdout]' \
+'--batch[output exection results to stdout]' \
+'-B[beep if command has a change result]' \
+'--beep[beep if command has a change result]' \
+'--border[Surround each pane with a border frame]' \
+'--with-scrollbar[When the border option is enabled, display scrollbar on the right side of watch pane.]' \
+'--mouse[enable mouse wheel support. With this option, copying text with your terminal may be harder. Try holding the Shift key.]' \
+'-c[interpret ANSI color and style sequences]' \
+'--color[interpret ANSI color and style sequences]' \
+'-r[display text upside down.]' \
+'--reverse[display text upside down.]' \
+'-C[Compress data in memory. Note\: If the output of the command is small, you may not get the desired effect.]' \
+'--compress[Compress data in memory. Note\: If the output of the command is small, you may not get the desired effect.]' \
+'-t[hide the UI on start. Use \`t\` to toggle it.]' \
+'--no-title[hide the UI on start. Use \`t\` to toggle it.]' \
+'-N[show line number]' \
+'--line-number[show line number]' \
+'--no-help-banner[hide the "Display help with h key" message]' \
+'-x[Run the command directly, not through the shell. Much like the \`-x\` option of the watch command.]' \
+'--exec[Run the command directly, not through the shell. Much like the \`-x\` option of the watch command.]' \
+'-O[Display only the lines with differences during \`line\` diff and \`word\` diff.]' \
+'--diff-output-only[Display only the lines with differences during \`line\` diff and \`word\` diff.]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+'*::command:_cmdambivalent' \
+&& ret=0
 }
+
+(( $+functions[_hwatch_commands] )) ||
+_hwatch_commands() {
+    local commands; commands=()
+    _describe -t commands 'hwatch commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_hwatch" ]; then
+    _hwatch "$@"
+else
+    compdef _hwatch hwatch
+fi


### PR DESCRIPTION
Generated using [clap_complete](https://docs.rs/clap_complete/latest/clap_complete/).

Perhaps we should use GitHub actions (e.g. https://github.com/ErrorNoInternet/hsize/commit/086bd3de83a1095982fbcd6b4a0202a770c0046e) or leverage a build.rs file (e.g. https://github.com/ErrorNoInternet/overmask/blob/main/build.rs) to automatically generate these?