### PR TITLE
feat: add termios for freebsd platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ unicode-segmentation = "1.10"
 unicode-truncate = "1"
 unicode-width = "=0.1.13"
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))'.dependencies]
 termios = "0.3"
 
 [package.metadata.binstall]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ extern crate ratatui as tui;
 extern crate unicode_width;
 extern crate unicode_segmentation;
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))]
 extern crate termios;
 
 // macro crate

--- a/src/view.rs
+++ b/src/view.rs
@@ -18,12 +18,12 @@ use std::{
 use tui::{backend::CrosstermBackend, Terminal};
 
 // non blocking io
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))]
 use std::{
     io::stdin,
     os::unix::io::AsRawFd,
 };
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))]
 use nix::fcntl::{fcntl, FcntlArg::*, OFlag};
 
 // local module
@@ -202,7 +202,7 @@ impl View {
             let input_tx = tx.clone();
             let _ = std::thread::spawn(move || {
                     // non blocking io
-                    #[cfg(any(target_os = "linux", target_os = "macos"))]
+                    #[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))]
                     loop {
                         let _ = send_input(input_tx.clone());
                     }
@@ -301,14 +301,14 @@ fn restore_terminal() {
 fn send_input(tx: Sender<AppEvent>) -> io::Result<()> {
     if crossterm::event::poll(Duration::from_millis(100))? {
         // non blocking mode
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        #[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))]
         set_nonblocking(true)?;
 
         // get event
         let result = crossterm::event::read();
 
         // blocking mode
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        #[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))]
         set_nonblocking(false)?;
 
         if let Ok(event) = result {
@@ -318,7 +318,7 @@ fn send_input(tx: Sender<AppEvent>) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))]
 pub fn set_nonblocking(is_nonblocking: bool) -> nix::Result<()> {
     let stdin_fd = stdin().as_raw_fd();
     let flags = fcntl(stdin_fd, F_GETFL)?;


### PR DESCRIPTION
Project builds without error on FreeBSD hosts using `cargo install hwatch`, but the resulting binary freezes after drawing the screen, and needs to be killed from another terminal. After being killed, the terminal's settings are corrupted.

I noticed `termios` crate is only used on `linux` and `macos` platforms and hoped that adding an extra `cfg` condition would be all it takes.

Here is that change. It resolves both the process freezing and terminal corruption. Tests pass.

This isn't really a bug, just adding platform support; so no tests are added.

Fixes #179 