### PR TITLE
Adds precise interval option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ That records the result of command execution and can display it history and diff
           -l, --logfile [<logfile>]           logging file. if a log file is already used, its contents will be read and executed.
           -s, --shell <shell_command>         shell to use at runtime. can also insert the command to the location specified by {COMMAND}. [default: "sh -c"]
           -n, --interval <interval>           seconds to wait between updates [default: 2]
+              --precise                       Attempt to run as close to the interval as possible, regardless of how long the command takes to run
           -L, --limit <limit>                 Set the number of history records to keep. only work in watch mode. Set `0` for unlimited recording. (default: 5000) [default: 5000]
               --tab-size <tab_size>           Specifying tab display size [default: 4]
           -d, --differences [<differences>]   highlight changes between updates [possible values: none, watch, line, word]

--- a/completion/bash/hwatch-completion.bash
+++ b/completion/bash/hwatch-completion.bash
@@ -19,7 +19,7 @@ _hwatch() {
 
     case "${cmd}" in
         hwatch)
-            opts="-b -B -c -r -C -t -N -x -O -A -l -s -n -L -d -o -K -h -V --batch --beep --border --with-scrollbar --mouse --color --reverse --compress --no-title --line-number --no-help-banner --exec --diff-output-only --aftercommand --logfile --shell --interval --limit --tab-size --differences --output --keymap --help --version [command]..."
+            opts="-b -B -c -r -C -t -N -x -O -A -l -s -n -L -d -o -K -h -V --batch --beep --border --with-scrollbar --mouse --color --reverse --compress --no-title --line-number --no-help-banner --exec --diff-output-only --aftercommand --logfile --shell --interval --precise --limit --tab-size --differences --output --keymap --help --version [command]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -72,6 +72,10 @@ _hwatch() {
                     return 0
                     ;;
                 --interval)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --precise)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completion/fish/hwatch.fish
+++ b/completion/fish/hwatch.fish
@@ -2,6 +2,7 @@ complete -c hwatch -s A -l aftercommand -d 'Executes the specified command if th
 complete -c hwatch -s l -l logfile -d 'logging file' -r -F
 complete -c hwatch -s s -l shell -d 'shell to use at runtime. can  also insert the command to the location specified by {COMMAND}.' -r -f -a "(__fish_complete_command)"
 complete -c hwatch -s n -l interval -d 'seconds to wait between updates' -r
+complete -c hwatch -s b -l precise -d 'Attempt to run as close to the interval as possible, regardless of how long the command takes to run'
 complete -c hwatch -s L -l limit -d 'Set the number of history records to keep. only work in watch mode. Set `0` for unlimited recording. (default: 5000)' -r
 complete -c hwatch -l tab-size -d 'Specifying tab display size' -r
 complete -c hwatch -s d -l differences -d 'highlight changes between updates' -r -f -a "{none\t'',watch\t'',line\t'',word\t''}"

--- a/completion/zsh/_hwatch
+++ b/completion/zsh/_hwatch
@@ -23,6 +23,7 @@ _hwatch() {
 '*--shell=[shell to use at runtime. can  also insert the command to the location specified by {COMMAND}.]: :_cmdstring' \
 '*-n+[seconds to wait between updates]: : ' \
 '*--interval=[seconds to wait between updates]: : ' \
+'--precise[Attempt to run as close to the interval as possible, regardless of how long the command takes to run]: : ' \
 '-L+[Set the number of history records to keep. only work in watch mode. Set \`0\` for unlimited recording. (default\: 5000)]: : ' \
 '--limit=[Set the number of history records to keep. only work in watch mode. Set \`0\` for unlimited recording. (default\: 5000)]: : ' \
 '*--tab-size=[Specifying tab display size]: : ' \

--- a/man/man.md
+++ b/man/man.md
@@ -109,6 +109,9 @@ Flags
 
 :   Display only the lines with differences during `line` diff and `word` diff.
 
+\--precise
+
+:   Attempt to run as close to the interval as possible, regardless of how long the command takes to run.
 
 Options
 -------


### PR DESCRIPTION
Addresses https://github.com/blacknon/hwatch/issues/111

This attempts to run the file as close to the desired interval as possible. I've observed that my Mac laptop is less accurate than my more powerful linux desktop. Perhaps it is because it takes time to run the stdout write?

This also handles the condition where the command has run for longer than the interval, which sets the next run to happen immediately. If that is not preferred we may want to change the logic.

For instance, the command I was testing with was `date && sleep 2`

If I run this with an interval of 3, it will run every 3 seconds, even though this command takes a little over 2 seconds to complete.

If I run it with an interval of 1, it will simply run immediately after it finishes (temporarily making the interval 0 for the next iteration).

However, if the desire was instead, "Run every 3 seconds, and I prefer skipping an iteration to running off cycle" we have no way to do that right now.

Finally, I updated the completion scripts and man pages as best I could, but was only able to test my particular situation (zsh and the --help command)