### PR TITLE
Fix typo "forcus" => "focus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ Keybind functions that can be specified are as follows.
 | move_end                 | Move end                                   |
 | watch_pane_move_end      | Move end in watch pane                     |
 | history_pane_move_end    | Move end in history pane                   |
-| toggle_forcus            | Toggle forcus window                       |
-| forcus_watch_pane        | Forcus watch pane                          |
-| forcus_history_pane      | Forcus history pane                        |
+| toggle_focus             | Toggle focus window                        |
+| focus_watch_pane         | Focus watch pane                           |
+| focus_history_pane       | Focus history pane                         |
 | quit                     | Quit hwatch                                |
 | reset                    | filter reset                               |
 | cancel                   | Cancel                                     |
@@ -192,8 +192,8 @@ Keybind functions that can be specified are as follows.
 | interval_plus            | Interval +0.5sec                           |
 | interval_minus           | Interval -0.5sec                           |
 | toggle_pause             | Toggle pause execution                     |
-| prev_keyword             | Forcus previous keyword                    |
-| next_keyword             | Forcus next keyword                        |
+| prev_keyword             | Focus previous keyword                     |
+| next_keyword             | Focus next keyword                         |
 | change_filter_mode       | Change filter mode                         |
 | change_regex_filter_mode | Change regex filter mode                   |
 

--- a/man/man.md
+++ b/man/man.md
@@ -289,11 +289,11 @@ F3
 
 Ctrl+P
 
-:   Forcus before keyword.
+:   Focus before keyword.
 
 Ctrl+N
 
-:   Forcus next keyword.
+:   Focus next keyword.
 
 Shif+O
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1263,9 +1263,9 @@ impl App<'_> {
                         InputAction::MoveEnd => self.action_end(),                    // MoveEnd
                         InputAction::WatchPaneMoveEnd => self.watch_area.scroll_end(), // Watch Pane MoveEnd
                         InputAction::HistoryPaneMoveEnd => self.action_history_end(), // History Pane MoveEnd
-                        InputAction::ToggleForcus => self.toggle_area(), // ToggleForcus
-                        InputAction::ForcusWatchPane => self.select_watch_pane(), // ForcusWatchPane
-                        InputAction::ForcusHistoryPane => self.select_history_pane(), // ForcusHistoryPane
+                        InputAction::ToggleFocus => self.toggle_area(),               // ToggleFocus
+                        InputAction::FocusWatchPane => self.select_watch_pane(), // FocusWatchPane
+                        InputAction::FocusHistoryPane => self.select_history_pane(), // FocusHistoryPane
                         InputAction::Quit => {
                             if self.disable_exit_dialog {
                                 self.exit();

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -88,9 +88,9 @@ const DEFAULT_KEYMAP: [&str; 46] = [
     "pagedown=page_down",                    // PageDown
     "home=move_top",                         // MoveTop: Home
     "end=move_end",                          // MoveEnd: End
-    "tab=toggle_forcus",                     // ToggleForcus: Tab
-    "left=forcus_watch_pane",                // ForcusWatchPane: Left
-    "right=forcus_history_pane",             // ForcusHistoryPane: Right
+    "tab=toggle_focus",                      // ToggleFocus: Tab
+    "left=focus_watch_pane",                 // FocusWatchPane: Left
+    "right=focus_history_pane",              // FocusHistoryPane: Right
     "alt-left=scroll_left",                  // Watch window scrll left: Alt + Left
     "shift-alt-left=scroll_horizontal_home", // Watch window scrll End left: Shift + Alt + Left
     "alt-right=scroll_right",                // Watch window scrll right: Alt + Right
@@ -543,14 +543,14 @@ pub enum InputAction {
     #[serde(rename = "history_pane_move_end")]
     HistoryPaneMoveEnd,
 
-    // Forcus
+    // Focus
     // ==========
-    #[serde(rename = "toggle_forcus")]
-    ToggleForcus,
-    #[serde(rename = "forcus_watch_pane")]
-    ForcusWatchPane,
-    #[serde(rename = "forcus_history_pane")]
-    ForcusHistoryPane,
+    #[serde(rename = "toggle_focus")]
+    ToggleFocus,
+    #[serde(rename = "focus_watch_pane")]
+    FocusWatchPane,
+    #[serde(rename = "focus_history_pane")]
+    FocusHistoryPane,
 
     // quit
     // ==========
@@ -733,10 +733,10 @@ pub fn get_input_action_description(input_action: InputAction) -> String {
         InputAction::WatchPaneMoveEnd => "Move end in watch pane".to_string(),
         InputAction::HistoryPaneMoveEnd => "Move end in history pane".to_string(),
 
-        // Forcus
-        InputAction::ToggleForcus => "Toggle forcus window".to_string(),
-        InputAction::ForcusWatchPane => "Forcus watch pane".to_string(),
-        InputAction::ForcusHistoryPane => "Forcus history pane".to_string(),
+        // Focus
+        InputAction::ToggleFocus => "Toggle focus window".to_string(),
+        InputAction::FocusWatchPane => "Focus watch pane".to_string(),
+        InputAction::FocusHistoryPane => "Focus history pane".to_string(),
 
         // Quit
         InputAction::Quit => "Quit hwatch".to_string(),
@@ -790,8 +790,8 @@ pub fn get_input_action_description(input_action: InputAction) -> String {
         InputAction::SetOutputModeStderr => "Set output mode stderr".to_string(),
 
         // Keyword search
-        InputAction::NextKeyword => "Forcus next keyword".to_string(),
-        InputAction::PrevKeyword => "Forcus previous keyword".to_string(),
+        InputAction::NextKeyword => "Focus next keyword".to_string(),
+        InputAction::PrevKeyword => "Focus previous keyword".to_string(),
 
         // Toggle Wrap
         InputAction::ToggleWrapMode => "Toggle wrap mode".to_string(),


### PR DESCRIPTION
I couldn't find the contributing guidelines but have run `cargo test` and all the tests passed.