### PR TITLE
Update help text for limit argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -364,7 +364,7 @@ fn build_app() -> clap::Command {
         //   [--limit,-L] size(default:5000)
         .arg(
             Arg::new("limit")
-                .help("Set the number of history records to keep. only work in watch mode. Set `0` for unlimited recording. (default: 5000)")
+                .help("Set the number of history records to keep. only work in watch mode. Set `0` for unlimited recording.")
                 .short('L')
                 .long("limit")
                 .value_parser(clap::value_parser!(u32))


### PR DESCRIPTION
Removed default value mention from limit help text as the default is already printed out by the clap library.

<img width="1376" height="76" alt="Screenshot 2025-08-29 at 15 35 43" src="https://github.com/user-attachments/assets/5f98288c-8b9e-456e-b9be-a4e0fe9710ae" />
