### PR TITLE
fix: add Windows support for input handling

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -190,7 +190,7 @@ impl View {
             let input_tx = tx.clone();
             let _ = std::thread::spawn(move || {
                 // non blocking io
-                #[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos"))]
+                #[cfg(any(target_os = "freebsd", target_os = "linux", target_os = "macos", target_os = "windows"))]
                 loop {
                     let _ = send_input(input_tx.clone());
                 }


### PR DESCRIPTION
#208

Extend platform compatibility to include Windows in the non-blocking input handling loop. This allows the input processing to work correctly on Windows systems alongside other supported platforms (freebsd, linux, macos).